### PR TITLE
Map updates

### DIFF
--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -12,29 +12,27 @@ inputs:
     type: 
       type: array
       items: File
-    description: "Input fastq files"
+    description: "Input fastq paired-end read 1 files"
   - id: "#input_fastq_read2_files"
     type:
       type: array
       items: File
-    description: "Input fastq files"
-  - id: "#genome_ref_index_files"
-    type:
-      type: array
-      items: File
-    description: "Bowtie index files for reference genome (*1.ebwt, *.2.ebwt, ...)"
+    description: "Input fastq paired-end read 2 files"
+  - id: "#genome_ref_first_index_file"
+    type: File
+    description: "Bowtie first index files for reference genome (e.g. *1.ebwt). The rest of the files should be in the same folder."
   - id: "#genome_sizes_file"
     type: File
     description: "Genome sizes tab-delimited file (used in samtools)"
   - id: "#ENCODE_blacklist_bedfile"
     type: File
     description: "Bedfile containing ENCODE consensus blacklist regions to be excluded."
-  - id: "#nthreads_mapping"
+  - id: "#nthreads"
     type: int
     default: 1
 
 outputs:
-  - id: "#output_data_sorted_filtered_bam_files"
+  - id: "#output_data_sorted_dedup_bam_files"
     source: "#filtered2sorted.sorted_file"
     description: "Filtered sorted aligned BAM files with Bowtie."
     type:
@@ -58,22 +56,48 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#pbc_files"
+  - id: "#output_preseq_c_curve_files"
+    source: "#preseq-c-curve.output_file"
+    description: "Preseq c_curve output files."
+    type:
+      type: array
+      items: File
+  - id: "#output_preseq_lc_extrap_files"
+    source: "#preseq-lc-extrap.output_file"
+    description: "Preseq lc_extrap output files."
+    type:
+      type: array
+      items: File
+  - id: "#output_pbc_files"
     source: "#execute_pcr_bottleneck_coef.pbc_file"
     description: "PCR Bottleneck Coeficient files."
     type:
       type: array
       items: File
+  - id: "#output_bowtie_log"
+    source: "#bowtie-pe.output_bowtie_log"
+    description: "Bowtie log file."
+    type:
+      type: array
+      items: File
 
 steps:
-  - id: "#extract_basename"
+  - id: "#extract_basename_1"
     run: {import: "../utils/extract-basename.cwl" }
-    scatter: "#extract_basename.input_file"
+    scatter: "#extract_basename_1.input_file"
     inputs:
-      - id: "#extract_basename.input_file"
+      - id: "#extract_basename_1.input_file"
         source: "#input_fastq_read1_files"
     outputs:
-      - id: "#extract_basename.output_basename"
+      - id: "#extract_basename_1.output_basename"
+  - id: "#extract_basename_2"
+    run: {import: "../utils/remove-extension.cwl" }
+    scatter: "#extract_basename_2.file_path"
+    inputs:
+      - id: "#extract_basename_2.file_path"
+        source: "#extract_basename_1.output_basename"
+    outputs:
+      - id: "#extract_basename_2.output_path"
   - id: "#bowtie-pe"
     run: {import: "../map/bowtie-pe.cwl"}
     scatter:
@@ -87,13 +111,14 @@ steps:
       - id: "#bowtie-pe.input_fastq_read2_file"
         source: "#input_fastq_read2_files"
       - id: "#bowtie-pe.output_filename"
-        source: "#extract_basename.output_basename"
-      - id: "#bowtie-pe.genome_ref_index_files"
-        source: "#genome_ref_index_files"
-      - id: "bowtie-pe.nthreads"
-        source: "#nthreads_mapping"
+        source: "#extract_basename_2.output_path"
+      - id: "#bowtie-se.genome_ref_first_index_file"
+        source: "#genome_ref_first_index_file"
+      - id: "#bowtie-pe.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#bowtie-pe.output_aligned_file"
+      - id: "#bowtie-pe.output_bowtie_log"
   - id: "#sam2bam"
     run: {import: "../map/samtools2bam.cwl"}
     scatter:
@@ -110,15 +135,21 @@ steps:
     inputs:
       - id: "#sort_bams.input_file"
         source: "#sam2bam.bam_file"
+      - id: "#sort_bams.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sort_bams.sorted_file"
   - id: "#filter-unmapped"
     run: {import: "../map/samtools-filter-unmapped.cwl"}
     scatter:
       - "#filter-unmapped.input_file"
+      - "#filter-unmapped.output_filename"
+    scatterMethod: dotproduct
     inputs:
       - id: "#filter-unmapped.input_file"
         source: "#sort_bams.sorted_file"
+      - id: "#filter-unmapped.output_filename"
+        source: "#extract_basename_2.output_path"
     outputs:
       - id: "#filter-unmapped.filtered_file"
   - id: "#filtered2sorted"
@@ -128,30 +159,42 @@ steps:
     inputs:
       - id: "#filtered2sorted.input_file"
         source: "#filter-unmapped.filtered_file"
+      - id: "#filtered2sorted.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#filtered2sorted.sorted_file"
-#  - id: "#extract_basename_sorted_bam"
-#    run: {import: "../utils/extract-basename.cwl" }
-#    scatter: "#extract_basename_sorted_bam.input_file"
-#    inputs:
-#      - id: "#extract_basename_sorted_bam.input_file"
-#        source: "#filtered2sorted.sorted_file"
-#    outputs:
-#      - id: "#extract_basename_sorted_bam.output_basename"
-#  - id: "#preseq-c-curve"
-#    run: {import: "../map/preseq-c_curve.cwl"}
-#    scatter:
-#      - "#preseq-c-curve.input_sorted_file"
-#      - "#preseq-c-curve.output_filename"
-#    scatterMethod: dotproduct
-#    inputs:
-#      - id: "#preseq-c-curve.input_sorted_file"
-#        source: "#filtered2sorted.sorted_file"
-#      - id: "#preseq-c-curve.output_filename"
-#        source: "#extract_basename_sorted_bam.output_basename"
-#    outputs:
-#      - id: "#preseq-c-curve.output_file"
-# TODO: Check why preseq is not working..
+  - id: "#preseq-c-curve"
+    run: {import: "../map/preseq-c_curve.cwl"}
+    scatter:
+      - "#preseq-c-curve.input_sorted_file"
+      - "#preseq-c-curve.output_file_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#preseq-c-curve.input_sorted_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#preseq-c-curve.output_file_basename"
+        source: "#extract_basename_2.output_path"
+      - id: "#preseq-c-curve.pe"
+        default: true
+    outputs:
+      - id: "#preseq-c-curve.output_file"
+  - id: "#preseq-lc-extrap"
+    run: {import: "../map/preseq-lc_extrap.cwl"}
+    scatter:
+      - "#preseq-lc-extrap.input_sorted_file"
+      - "#preseq-lc-extrap.output_file_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#preseq-lc-extrap.input_sorted_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#preseq-lc-extrap.output_file_basename"
+        source: "#extract_basename_2.output_path"
+      - id: "#preseq-lc-extrap.s"
+        default: 100000
+      - id: "#preseq-lc-extrap.pe"
+        default: true
+    outputs:
+      - id: "#preseq-lc-extrap.output_file"
   - id: "#execute_pcr_bottleneck_coef"
     run: {import: "../map/pcr-bottleneck-coef.cwl"}
     inputs:
@@ -159,16 +202,22 @@ steps:
         source: "#filtered2sorted.sorted_file"
       - id: "#execute_pcr_bottleneck_coef.genome_sizes"
         source: "#genome_sizes_file"
+      - id: "#execute_pcr_bottleneck_coef.input_output_filenames"
+        source: "#extract_basename_2.output_path"
     outputs:
       - id: "#execute_pcr_bottleneck_coef.pbc_file"
   - id: "#remove_duplicates"
     run: {import: "../map/picard-MarkDuplicates.cwl"}
     scatter:
       - "#remove_duplicates.input_file"
+      - "#remove_duplicates.output_filename"
+    scatterMethod: dotproduct
     inputs:
       - id: "#remove_duplicates.input_file"
         source: "#filtered2sorted.sorted_file"
-      - id: "#absolute_path_to_picard_jar"
+      - id: "#remove_duplicates.output_filename"
+        source: "#extract_basename_2.output_path"
+      - id: "#remove_duplicates.absolute_path_to_picard_jar"
         default: "/usr/picard/picard.jar"
     outputs:
       - id: "#remove_duplicates.output_metrics_file"
@@ -177,9 +226,13 @@ steps:
     run: {import: "../map/bedtools-intersect.cwl"}
     scatter:
       - "#remove_encode_blacklist.a"
+      - "#remove_encode_blacklist.output_basename_file"
+    scatterMethod: dotproduct
     inputs:
       - id: "#remove_encode_blacklist.v"
         default: true
+      - id: "#remove_encode_blacklist.output_basename_file"
+        source: "#extract_basename_2.output_path"
       - id: "#remove_encode_blacklist.a"
         source: "#remove_duplicates.output_dedup_bam_file"
       - id: "#remove_encode_blacklist.b"
@@ -193,6 +246,8 @@ steps:
     inputs:
       - id: "#sort_dedup_bams.input_file"
         source: "#remove_encode_blacklist.file_wo_blacklist_regions"
+      - id: "#sort_dedup_bams.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sort_dedup_bams.sorted_file"
   - id: "#index_dedup_bams"

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -22,7 +22,7 @@ inputs:
   - id: "#ENCODE_blacklist_bedfile"
     type: File
     description: "Bedfile containing ENCODE consensus blacklist regions to be excluded."
-  - id: "#nthreads_mapping"
+  - id: "#nthreads"
     type: int
     default: 1
 
@@ -107,7 +107,7 @@ steps:
       - id: "#bowtie-se.genome_ref_first_index_file"
         source: "#genome_ref_first_index_file"
       - id: "bowtie-se.nthreads"
-        source: "#nthreads_mapping"
+        source: "#nthreads"
     outputs:
       - id: "#bowtie-se.output_aligned_file"
       - id: "#bowtie-se.output_bowtie_log"
@@ -127,6 +127,8 @@ steps:
     inputs:
       - id: "#sort_bams.input_file"
         source: "#sam2bam.bam_file"
+      - id: "#sort_bams.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sort_bams.sorted_file"
   - id: "#filter-unmapped"
@@ -149,6 +151,8 @@ steps:
     inputs:
       - id: "#filtered2sorted.input_file"
         source: "#filter-unmapped.filtered_file"
+      - id: "#filtered2sorted.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#filtered2sorted.sorted_file"
   - id: "#preseq-c-curve"
@@ -230,6 +234,8 @@ steps:
     inputs:
       - id: "#sort_dedup_bams.input_file"
         source: "#remove_encode_blacklist.file_wo_blacklist_regions"
+      - id: "#sort_dedup_bams.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sort_dedup_bams.sorted_file"
   - id: "#index_dedup_bams"

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -13,11 +13,9 @@ inputs:
       type: array
       items: File
     description: "Input fastq files"
-  - id: "#genome_ref_index_files"
-    type:
-      type: array
-      items: File
-    description: "Bowtie index files for reference genome (*1.ebwt, *.2.ebwt, ...)"
+  - id: "#genome_ref_first_index_file"
+    type: File
+    description: "Bowtie first index files for reference genome (*1.ebwt). The rest of the files should be in the same folder."
   - id: "#genome_sizes_file"
     type: File
     description: "Genome sizes tab-delimited file (used in samtools)"
@@ -29,7 +27,7 @@ inputs:
     default: 1
 
 outputs:
-  - id: "#output_data_sorted_filtered_bam_files"
+  - id: "#output_sorted_dedup_bam_files"
     source: "#filtered2sorted.sorted_file"
     description: "Filtered sorted aligned BAM files with Bowtie."
     type:
@@ -53,28 +51,48 @@ outputs:
     type:
       type: array
       items: File
-#  - id: "#output_preseq_c_curve_files"
-#    source: "#preseq-c-curve.output_file"
-#    description: "Preseq c_curve output files."
-#    type:
-#      type: array
-#      items: File
-  - id: "#pbc_files"
+  - id: "#output_preseq_c_curve_files"
+    source: "#preseq-c-curve.output_file"
+    description: "Preseq c_curve output files."
+    type:
+      type: array
+      items: File
+  - id: "#output_preseq_lc_extrap_files"
+    source: "#preseq-lc-extrap.output_file"
+    description: "Preseq lc_extrap output files."
+    type:
+      type: array
+      items: File
+  - id: "#output_pbc_files"
     source: "#execute_pcr_bottleneck_coef.pbc_file"
     description: "PCR Bottleneck Coeficient files."
     type:
       type: array
       items: File
+  - id: "#output_bowtie_log"
+    source: "#bowtie-se.output_bowtie_log"
+    description: "Bowtie log file."
+    type:
+      type: array
+      items: File
 
 steps:
-  - id: "#extract_basename"
+  - id: "#extract_basename_1"
     run: {import: "../utils/extract-basename.cwl" }
-    scatter: "#extract_basename.input_file"
+    scatter: "#extract_basename_1.input_file"
     inputs:
-      - id: "#extract_basename.input_file"
+      - id: "#extract_basename_1.input_file"
         source: "#input_fastq_files"
     outputs:
-      - id: "#extract_basename.output_basename"
+      - id: "#extract_basename_1.output_basename"
+  - id: "#extract_basename_2"
+    run: {import: "../utils/remove-extension.cwl" }
+    scatter: "#extract_basename_2.file_path"
+    inputs:
+      - id: "#extract_basename_2.file_path"
+        source: "#extract_basename_1.output_basename"
+    outputs:
+      - id: "#extract_basename_2.output_path"
   - id: "#bowtie-se"
     run: {import: "../map/bowtie-se.cwl"}
     scatter:
@@ -85,13 +103,14 @@ steps:
       - id: "#bowtie-se.input_fastq_file"
         source: "#input_fastq_files"
       - id: "#bowtie-se.output_filename"
-        source: "#extract_basename.output_basename"
-      - id: "#bowtie-se.genome_ref_index_files"
-        source: "#genome_ref_index_files"
+        source: "#extract_basename_2.output_path"
+      - id: "#bowtie-se.genome_ref_first_index_file"
+        source: "#genome_ref_first_index_file"
       - id: "bowtie-se.nthreads"
         source: "#nthreads_mapping"
     outputs:
       - id: "#bowtie-se.output_aligned_file"
+      - id: "#bowtie-se.output_bowtie_log"
   - id: "#sam2bam"
     run: {import: "../map/samtools2bam.cwl"}
     scatter:
@@ -114,9 +133,13 @@ steps:
     run: {import: "../map/samtools-filter-unmapped.cwl"}
     scatter:
       - "#filter-unmapped.input_file"
+      - "#filter-unmapped.output_filename"
+    scatterMethod: dotproduct
     inputs:
       - id: "#filter-unmapped.input_file"
         source: "#sort_bams.sorted_file"
+      - id: "#filter-unmapped.output_filename"
+        source: "#extract_basename_2.output_path"
     outputs:
       - id: "#filter-unmapped.filtered_file"
   - id: "#filtered2sorted"
@@ -128,28 +151,34 @@ steps:
         source: "#filter-unmapped.filtered_file"
     outputs:
       - id: "#filtered2sorted.sorted_file"
-#  - id: "#extract_basename_sorted_bam"
-#    run: {import: "../utils/extract-basename.cwl" }
-#    scatter: "#extract_basename_sorted_bam.input_file"
-#    inputs:
-#      - id: "#extract_basename_sorted_bam.input_file"
-#        source: "#filtered2sorted.sorted_file"
-#    outputs:
-#      - id: "#extract_basename_sorted_bam.output_basename"
-#  - id: "#preseq-c-curve"
-#    run: {import: "../map/preseq-c_curve.cwl"}
-#    scatter:
-#      - "#preseq-c-curve.input_sorted_file"
-#      - "#preseq-c-curve.output_filename"
-#    scatterMethod: dotproduct
-#    inputs:
-#      - id: "#preseq-c-curve.input_sorted_file"
-#        source: "#filtered2sorted.sorted_file"
-#      - id: "#preseq-c-curve.output_filename"
-#        source: "#extract_basename_sorted_bam.output_basename"
-#    outputs:
-#      - id: "#preseq-c-curve.output_file"
-# TODO: Check why preseq is not working..
+  - id: "#preseq-c-curve"
+    run: {import: "../map/preseq-c_curve.cwl"}
+    scatter:
+      - "#preseq-c-curve.input_sorted_file"
+      - "#preseq-c-curve.output_file_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#preseq-c-curve.input_sorted_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#preseq-c-curve.output_file_basename"
+        source: "#extract_basename_2.output_path"
+    outputs:
+      - id: "#preseq-c-curve.output_file"
+  - id: "#preseq-lc-extrap"
+    run: {import: "../map/preseq-lc_extrap.cwl"}
+    scatter:
+      - "#preseq-lc-extrap.input_sorted_file"
+      - "#preseq-lc-extrap.output_file_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#preseq-lc-extrap.input_sorted_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#preseq-lc-extrap.output_file_basename"
+        source: "#extract_basename_2.output_path"
+      - id: "#preseq-lc-extrap.s"
+        default: 100000
+    outputs:
+      - id: "#preseq-lc-extrap.output_file"
   - id: "#execute_pcr_bottleneck_coef"
     run: {import: "../map/pcr-bottleneck-coef.cwl"}
     inputs:
@@ -157,16 +186,22 @@ steps:
         source: "#filtered2sorted.sorted_file"
       - id: "#execute_pcr_bottleneck_coef.genome_sizes"
         source: "#genome_sizes_file"
+      - id: "#execute_pcr_bottleneck_coef.input_output_filenames"
+        source: "#extract_basename_2.output_path"
     outputs:
       - id: "#execute_pcr_bottleneck_coef.pbc_file"
   - id: "#remove_duplicates"
     run: {import: "../map/picard-MarkDuplicates.cwl"}
     scatter:
       - "#remove_duplicates.input_file"
+      - "#remove_duplicates.output_filename"
+    scatterMethod: dotproduct
     inputs:
       - id: "#remove_duplicates.input_file"
         source: "#filtered2sorted.sorted_file"
-      - id: "#absolute_path_to_picard_jar"
+      - id: "#remove_duplicates.output_filename"
+        source: "#extract_basename_2.output_path"
+      - id: "#remove_duplicates.absolute_path_to_picard_jar"
         default: "/usr/picard/picard.jar"
     outputs:
       - id: "#remove_duplicates.output_metrics_file"
@@ -175,9 +210,13 @@ steps:
     run: {import: "../map/bedtools-intersect.cwl"}
     scatter:
       - "#remove_encode_blacklist.a"
+      - "#remove_encode_blacklist.output_basename_file"
+    scatterMethod: dotproduct
     inputs:
       - id: "#remove_encode_blacklist.v"
         default: true
+      - id: "#remove_encode_blacklist.output_basename_file"
+        source: "#extract_basename_2.output_path"
       - id: "#remove_encode_blacklist.a"
         source: "#remove_duplicates.output_dedup_bam_file"
       - id: "#remove_encode_blacklist.b"

--- a/map/bedtools-intersect.cwl
+++ b/map/bedtools-intersect.cwl
@@ -299,12 +299,15 @@ inputs:
     inputBinding:
       position: 1
       prefix: '-iobuf'
+  - id: "#output_basename_file"
+    type: string
+
 outputs:
   - id: '#file_wo_blacklist_regions'
     type: File
     outputBinding:
-      glob: $(inputs.a.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.filtered.bam')
-stdout: $(inputs.a.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.filtered.bam')
+      glob: $(inputs.output_basename_file + '.dedup_filtered.bam')
+stdout: $(inputs.output_basename_file + '.dedup_filtered.bam')
 baseCommand:
   - bedtools
   - intersect

--- a/map/bowtie-pe.cwl
+++ b/map/bowtie-pe.cwl
@@ -67,11 +67,18 @@ inputs:
     inputBinding:
       position: 8
       prefix: "--threads"
-  - id: "#genome_ref_index_files"
-    description: "Bowtie index files for the reference genome"
-    type:
-      type: array
-      items: File
+  - id: "#genome_ref_first_index_file"
+    description: "First file (extension .1.ebwt) of the Bowtie index files generated for the reference genome (see http://bowtie-bio.sourceforge.net/tutorial.shtml#newi)"
+    type: File
+    secondaryFiles:
+      - "^^.2.ebwt"
+      - "^^.3.ebwt"
+      - "^^.4.ebwt"
+      - "^^.rev.1.ebwt"
+      - "^^.rev.2.ebwt"
+    inputBinding:
+      position: 9
+      valueFrom: $(self.path.split('.').splice(0,self.path.split('.').length-2).join("."))
   - id: "#input_fastq_read1_file"
     description: "Query input FASTQ file."
     type: File
@@ -100,8 +107,6 @@ outputs:
 
 baseCommand: bowtie
 arguments:
-  - valueFrom: $(inputs.genome_ref_index_files[0].path.split('.').splice(0,inputs.genome_ref_index_files[0].path.split('.').length-2).join("."))
-    position: 9
   - valueFrom: $(inputs.output_filename + '.sam')
     position: 12
   - valueFrom: $('2> ' + inputs.output_filename + '.bowtie.log')

--- a/map/bowtie-se.cwl
+++ b/map/bowtie-se.cwl
@@ -67,11 +67,18 @@ inputs:
     inputBinding:
       position: 8
       prefix: "--threads"
-  - id: "#genome_ref_index_files"
-    description: "Bowtie index files for the reference genome"
-    type:
-      type: array
-      items: File
+  - id: "#genome_ref_first_index_file"
+    description: "First file (extension .1.ebwt) of the Bowtie index files generated for the reference genome (see http://bowtie-bio.sourceforge.net/tutorial.shtml#newi)"
+    type: File
+    secondaryFiles:
+      - "^^.2.ebwt"
+      - "^^.3.ebwt"
+      - "^^.4.ebwt"
+      - "^^.rev.1.ebwt"
+      - "^^.rev.2.ebwt"
+    inputBinding:
+      position: 9
+      valueFrom: $(self.path.split('.').splice(0,self.path.split('.').length-2).join("."))
   - id: "#input_fastq_file"
     description: "Query input FASTQ file."
     type: File
@@ -93,8 +100,6 @@ outputs:
 
 baseCommand: bowtie
 arguments:
-  - valueFrom: $(inputs.genome_ref_index_files[0].path.split('.').splice(0,inputs.genome_ref_index_files[0].path.split('.').length-2).join("."))
-    position: 9
   - valueFrom: $(inputs.output_filename + '.sam')
     position: 11
   - valueFrom: $('2> ' + inputs.output_filename + '.bowtie.log')

--- a/map/compute-pbc.cwl
+++ b/map/compute-pbc.cwl
@@ -8,14 +8,16 @@ inputs:
     type: File
     inputBinding:
       position: 1
+  - id: "#output_filename"
+    type: string
 
 outputs:
   - id: "#pbc"
     type: File
     outputBinding:
-      glob: $(inputs.bedgraph_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.PBC.txt')
+      glob: $(inputs.output_filename + '.PBC.txt')
 
 baseCommand:
   - awk
   - '$4==1 {N1 += $3 - $2}; $4>=1 {Nd += $3 - $2} END {print N1/Nd}'
-stdout: $(inputs.bedgraph_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.PBC.txt')
+stdout: $(inputs.output_filename + '.PBC.txt')

--- a/map/pcr-bottleneck-coef.cwl
+++ b/map/pcr-bottleneck-coef.cwl
@@ -11,6 +11,10 @@ inputs:
     type:
       type: array
       items: File
+  - id: "#input_output_filenames"
+    type:
+      type: array
+      items: string
   - id: "#genome_sizes"
     type: File
 
@@ -36,14 +40,14 @@ steps:
       - id: "#bedtools_genomecov.output_bedfile"
   - id: "#compute_pbc"
     run: {import: "compute-pbc.cwl"}
-    scatter: "#compute_pbc.bedgraph_file"
+    scatter:
+      - "#compute_pbc.bedgraph_file"
+      - "#compute_pbc.output_filename"
+    scatterMethod: dotproduct
     inputs:
       - id: "#compute_pbc.bedgraph_file"
         source: "#bedtools_genomecov.output_bedfile"
+      - id: "#compute_pbc.output_filename"
+        source: "#input_output_filenames"
     outputs:
       - id: "#compute_pbc.pbc"
-
-## compute PCR bottleneck coefficient
-#bedtools genomecov -bg -ibam ${SAMPLE}.sorted.bam -g $GENOME_SIZES > ${SAMPLE}.sorted.bdg
-#awk '$4==1 {N1 += $3 - $2 - 1}; $4>=1 {Nd += $3 - $2 - 1} END {print N1/Nd}' ${SAMPLE}.sorted.bdg > ${SAMPLE}.PBC.txt
-#rm ${SAMPLE}.sorted.bdg

--- a/map/picard-MarkDuplicates.cwl
+++ b/map/picard-MarkDuplicates.cwl
@@ -19,7 +19,10 @@ inputs:
       position: 4
       valueFrom: $('INPUT=' + self.path)
       shellQuote: false
-
+  - id: "#output_filename"
+    type: string
+    description: "Output filename used as basename"
+      
   - id: "#java_Xms"
     type: string
     description: "Starting memory allocation pool for a Java Virtual Machine (JVM)"
@@ -58,26 +61,19 @@ outputs:
   - id: '#output_metrics_file'
     type: File
     outputBinding:
-      glob: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.' + inputs.metrics_suffix)
+      glob: $(inputs.output_filename + '.' + inputs.metrics_suffix)
   - id: '#output_dedup_bam_file'
     type: File
     outputBinding:
-      glob: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.')  + '.' + inputs.output_suffix)
+      glob: $(inputs.output_filename  + '.' + inputs.output_suffix)
 
 baseCommand: ["java"]
 arguments:
   - valueFrom: "MarkDuplicates"
     position: 3
-  - valueFrom: $('OUTPUT=' + inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.' + inputs.output_suffix)
+  - valueFrom: $('OUTPUT=' + inputs.output_filename + '.' + inputs.output_suffix)
     position: 5
     shellQuote: false
-  - valueFrom: $('METRICS_FILE='+inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.' + inputs.metrics_suffix)
+  - valueFrom: $('METRICS_FILE='+inputs.output_filename + '.' + inputs.metrics_suffix)
     position: 5
     shellQuote: false
-
-# remove duplicates
-#java -Xms12000m -Xmx12000m -jar /data/reddylab/software/picard/dist/picard.jar MarkDuplicates \
-#INPUT=${SAMPLE}.accepted_hits.bam \
-#OUTPUT=${SAMPLE}.dedup.bam \
-#METRICS_FILE=picard.${SAMPLE}_dedup_metrics.txt \
-#REMOVE_DUPLICATES=TRUE CREATE_INDEX=TRUE

--- a/map/preseq-c_curve.cwl
+++ b/map/preseq-c_curve.cwl
@@ -10,7 +10,7 @@ requirements:
   - class: InlineJavascriptRequirement
 
 inputs:
-  - id: output_filename
+  - id: output_file_basename
     type: string
   - id: input_sorted_file
     type: File
@@ -32,9 +32,10 @@ inputs:
     inputBinding:
       position: 1
       prefix: '-v'
-  - id: P
-    type: boolean
-    default: false
+  - id: pe
+    type:
+      - 'null'
+      - boolean
     description: "-pe       input is paired end read file \n"
     inputBinding:
       position: 1
@@ -74,8 +75,8 @@ outputs:
   - id: '#output_file'
     type: File
     outputBinding:
-      glob: $(inputs.output_filename)
-stdout: $(inputs.output_filename)
+      glob: $(inputs.output_file_basename + '.preseq_c_curve.txt')
+stdout: $(inputs.output_file_basename + '.preseq_c_curve.txt')
 baseCommand:
   - preseq
   - c_curve

--- a/map/preseq-lc_extrap.cwl
+++ b/map/preseq-lc_extrap.cwl
@@ -1,0 +1,131 @@
+#!/usr/bin/env cwl-runner
+
+class: CommandLineTool
+
+hints:
+  - class: DockerRequirement
+    dockerImageId: 'dukegcb/preseq'
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: output_file_basename
+    type: string
+  - id: input_sorted_file
+    type: File
+    description: 'Sorted bed or BAM file'
+    inputBinding:
+      position: 2
+  - id: e
+    type:
+      - 'null'
+      - boolean
+    description: "-extrap      maximum extrapolation (default: 1e+10) \n"
+    inputBinding:
+      position: 1
+      prefix: '-e'
+  - id: s
+    type:
+      - 'null'
+      - float
+    description: "-step        step size in extrapolations (default: 1e+06) \n"
+    inputBinding:
+      position: 1
+      prefix: '-s'
+  - id: 'n'
+    type:
+      - 'null'
+      - boolean
+    description: "-bootstraps  number of bootstraps (default: 100), \n"
+    inputBinding:
+      position: 1
+      prefix: '-n'
+  - id: c
+    type:
+      - 'null'
+      - boolean
+    description: "-cval        level for confidence intervals (default: 0.95) \n"
+    inputBinding:
+      position: 1
+      prefix: '-c'
+  - id: x
+    type:
+      - 'null'
+      - boolean
+    description: "-terms       maximum number of terms \n"
+    inputBinding:
+      position: 1
+      prefix: '-x'
+  - id: v
+    type:
+      - 'null'
+      - boolean
+    description: "-verbose     print more information \n"
+    inputBinding:
+      position: 1
+      prefix: '-v'
+  - id: B
+    type: boolean
+    default: true
+    description: "-bam         input is in BAM format \n"
+    inputBinding:
+      position: 1
+      prefix: '-B'
+  - id: l
+    type:
+      - 'null'
+      - boolean
+    description: "-seg_len     maximum segment length when merging paired end bam reads \n(default: 5000)\n"
+    inputBinding:
+      position: 1
+      prefix: '-l'
+  - id: pe
+    type:
+      - 'null'
+      - boolean
+    description: "-pe          input is paired end read file \n"
+    inputBinding:
+      position: 1
+      prefix: '-P'
+  - id: V
+    type:
+      - 'null'
+      - string
+    description: "-vals        input is a text file containing only the observed counts \n"
+    inputBinding:
+      position: 1
+      prefix: '-V'
+  - id: H
+    type:
+      - 'null'
+      - string
+    description: "-hist        input is a text file containing the observed histogram \n"
+    inputBinding:
+      position: 1
+      prefix: '-H'
+  - id: Q
+    type:
+      - 'null'
+      - boolean
+    description: "-quick       quick mode, estimate yield without bootstrapping for \nconfidence intervals\n"
+    inputBinding:
+      position: 1
+      prefix: '-Q'
+  - id: D
+    type:
+      - 'null'
+      - boolean
+    description: "-defects     defects mode to extrapolate without testing for defects \nHelp options:\n-?, -help        print this help message\n-about       print about message\n"
+    inputBinding:
+      position: 1
+outputs:
+  - id: '#output_file'
+    type: File
+    outputBinding:
+      glob: $(inputs.output_file_basename + '.preseq_lc_extrap.txt')
+stdout: $(inputs.output_file_basename + '.preseq_lc_extrap.txt')
+baseCommand:
+  - preseq
+  - lc_extrap
+description: "Usage: lc_extrap [OPTIONS] <sorted-bed-file>\n\nOptions:\n  -o, -output      yield output file (default: stdout) \n  -e, -extrap      maximum extrapolation (default: 1e+10) \n  -s, -step        step size in extrapolations (default: 1e+06) \n  -n, -bootstraps  number of bootstraps (default: 100), \n  -c, -cval        level for confidence intervals (default: 0.95) \n  -x, -terms       maximum number of terms \n  -v, -verbose     print more information \n  -B, -bam         input is in BAM format \n  -l, -seg_len     maximum segment length when merging paired end bam reads \n                   (default: 5000) \n  -P, -pe          input is paired end read file \n  -V, -vals        input is a text file containing only the observed counts \n  -H, -hist        input is a text file containing the observed histogram \n  -Q, -quick       quick mode, estimate yield without bootstrapping for \n                   confidence intervals \n  -D, -defects     defects mode to extrapolate without testing for defects \n\nHelp options:\n  -?, -help        print this help message \n      -about       print about message"

--- a/map/samtools-filter-unmapped.cwl
+++ b/map/samtools-filter-unmapped.cwl
@@ -14,13 +14,13 @@ inputs:
     type: File
     description: "Aligned file to be sorted with samtools"
     inputBinding:
-      position: 1
+      position: 1000
   - id: "#nthreads"
     type: int
     default: 1
     description: "Number of threads used in sorting"
     inputBinding:
-      position: 2
+      position: 1
       prefix: "-@"
   - id: "#output_filename"
     type: string

--- a/map/samtools-filter-unmapped.cwl
+++ b/map/samtools-filter-unmapped.cwl
@@ -15,16 +15,23 @@ inputs:
     description: "Aligned file to be sorted with samtools"
     inputBinding:
       position: 1
+  - id: "#nthreads"
+    type: int
+    default: 1
+    description: "Number of threads used in sorting"
+    inputBinding:
+      position: 2
+      prefix: "-@"
+  - id: "#output_filename"
+    type: string
+    description: "Basename for the output file"
 
 outputs:
   - id: "#filtered_file"
     type: File
     description: "Filter unmapped reads in aligned file"
     outputBinding:
-      glob: "*.accepted_hits"
-      outputEval: $(self[0])
+      glob: $(inputs.output_filename + '.accepted_hits.bam')
 
 baseCommand: ["samtools", "view", "-F", "4", "-b", "-h" ]
-stdout: $(inputs.input_file.path.split('/').slice(-1)[0] + '.accepted_hits')
-
-#samtools view -F 4 -b -h -o ${SAMPLE}.accepted_hits.bam ${SAMPLE}.sorted.bam
+stdout: $(inputs.output_filename + '.accepted_hits.bam')

--- a/map/samtools-sort.cwl
+++ b/map/samtools-sort.cwl
@@ -14,14 +14,21 @@ inputs:
     type: File
     description: "Aligned file to be sorted with samtools"
     inputBinding:
+      position: 1000
+  - id: "#nthreads"
+    type: int
+    default: 1
+    description: "Number of threads used in sorting"
+    inputBinding:
       position: 1
+      prefix: "-@"
 
 outputs:
   - id: "#sorted_file"
     type: File
     description: "Sorted aligned file"
     outputBinding:
-      glob: $(inputs.input_file.path.split('/').slice(-1)[0] + '.sorted')
+      glob: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sorted.bam')
 
 baseCommand: ["samtools", "sort"]
-stdout: $(inputs.input_file.path.split('/').slice(-1)[0] + '.sorted')
+stdout: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sorted.bam')


### PR DESCRIPTION
There are a bunch of files changing here, but conceptually it could be summarized in:

- Added support for Preseq lc_extract which allows to get an estimation of how much improvement in the number of uniquely mapped reads would be gained by increasing the sequencing depth,
- Restored preseq c_curve, which was not working before, 
- Changed the way in which the Bowtie index files are passed to the workflow (now only the 1st file needs to be specified, the rest of the files are fetched from the same folder as secondaryFiles),
- Added nthreads parameter for those tools supporting multithreading,
- Bowtie output log captured as a reported output file 
