### PR TITLE
Slurm fixes

### DIFF
--- a/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
@@ -33,6 +33,17 @@ inputs:
   - id: "#quality_score"
     type: string
     default: "-phred33"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    default: "/usr/share/java/trimmomatic.jar"
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 
 outputs:
   - id: "#output_data_fastq_read1_trimmed_files"
@@ -90,6 +101,10 @@ steps:
         source: "#concat_adapters.output_file"
       - id: "#trimmomatic-pe.nthreads"
         source: "#nthreads"
+      - id: "#trimmomatic-pe.java_opts"
+        source: "#trimmomatic_java_opts"
+      - id: "#trimmomatic-pe.trimmomatic_jar_path"
+        source: "#trimmomatic_jar_path"
     outputs:
       - id: "#trimmomatic-pe.output_read1_trimmed_paired_file"
 #      - id: "#trimmomatic-pe.output_read1_trimmed_unpaired_file"

--- a/GGR_ChIP-seq_pipeline/02-trim-se.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-se.cwl
@@ -19,6 +19,17 @@ inputs:
   - id: "#nthreads"
     type: int
     default: 1
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    default: "/usr/share/java/trimmomatic.jar"
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 
 outputs:
   - id: "#output_data_fastq_trimmed_files"
@@ -48,6 +59,10 @@ steps:
         source: "#input_adapters_files"
       - id: "#trimmomatic-se.nthreads"
         source: "#nthreads"
+      - id: "#trimmomatic-se.java_opts"
+        source: "#trimmomatic_java_opts"
+      - id: "#trimmomatic-se.trimmomatic_jar_path"
+        source: "#trimmomatic_jar_path"
     outputs:
       - id: "#trimmomatic-se.output_trimmed_file"
   - id: "#extract_basename"

--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -41,12 +41,6 @@ inputs:
     description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 
 outputs:
-  - id: "#output_data_sorted_dedup_bam_files"
-    source: "#filtered2sorted.sorted_file"
-    description: "Filtered sorted aligned BAM files with Bowtie."
-    type:
-      type: array
-      items: File
   - id: "#output_picard_mark_duplicates_files"
     source: "#remove_duplicates.output_metrics_file"
     description: "Picard MarkDuplicates metrics files."

--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -226,8 +226,10 @@ steps:
         source: "#filtered2sorted.sorted_file"
       - id: "#remove_duplicates.output_filename"
         source: "#extract_basename_2.output_path"
-      - id: "#remove_duplicates.absolute_path_to_picard_jar"
-        default: "/usr/picard/picard.jar"
+      - id: "#remove_duplicates.java_opts"
+        source: "#picard_java_opts"
+      - id: "#remove_duplicates.picard_jar_path"
+        source: "#picard_jar_path"
     outputs:
       - id: "#remove_duplicates.output_metrics_file"
       - id: "#remove_duplicates.output_dedup_bam_file"

--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -30,6 +30,15 @@ inputs:
   - id: "#nthreads"
     type: int
     default: 1
+  - id: "#picard_jar_path"
+    type: string
+    default: "/usr/picard/picard.jar"
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 
 outputs:
   - id: "#output_data_sorted_dedup_bam_files"

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -25,6 +25,15 @@ inputs:
   - id: "#nthreads"
     type: int
     default: 1
+  - id: "#picard_jar_path"
+    type: string
+    default: "/usr/picard/picard.jar"
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 
 outputs:
   - id: "#output_sorted_dedup_bam_files"

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -214,8 +214,10 @@ steps:
         source: "#filtered2sorted.sorted_file"
       - id: "#remove_duplicates.output_filename"
         source: "#extract_basename_2.output_path"
-      - id: "#remove_duplicates.absolute_path_to_picard_jar"
-        default: "/usr/picard/picard.jar"
+      - id: "#remove_duplicates.java_opts"
+        source: "#picard_java_opts"
+      - id: "#remove_duplicates.picard_jar_path"
+        source: "#picard_jar_path"
     outputs:
       - id: "#remove_duplicates.output_metrics_file"
       - id: "#remove_duplicates.output_dedup_bam_file"

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-broad-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-broad-with-control.cwl
@@ -49,6 +49,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_treatment_count_raw_reads_read1"
     source: "#qc_treatment.output_count_raw_reads_read1"
@@ -293,6 +303,8 @@ steps:
       - { id: "#trimm_treatment.input_read1_adapters_files", source: "#qc_treatment.output_custom_adapters_read1" }
       - { id: "#trimm_treatment.input_read2_adapters_files", source: "#qc_treatment.output_custom_adapters_read2" }
       - { id: "#trimm_treatment.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_treatment.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_treatment.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm_treatment.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm_treatment.output_data_fastq_read2_trimmed_files" }
@@ -338,6 +350,8 @@ steps:
       - { id: "#trimm_control.input_read1_adapters_files", source: "#qc_control.output_custom_adapters_read1" }
       - { id: "#trimm_control.input_read2_adapters_files", source: "#qc_control.output_custom_adapters_read2" }
       - { id: "#trimm_control.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_control.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_control.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm_control.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm_control.output_data_fastq_read2_trimmed_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-broad-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-broad-with-control.cwl
@@ -50,15 +50,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_treatment_count_raw_reads_read1"
     source: "#qc_treatment.output_count_raw_reads_read1"
@@ -319,6 +325,8 @@ steps:
       - { id: "#map_treatment.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_treatment.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_treatment.nthreads", source: "#nthreads_map" }
+      - { id: "#map_treatment.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_treatment.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_treatment.output_data_sorted_dedup_bam_files" }
       - { id: "#map_treatment.output_index_dedup_bam_files" }
@@ -366,6 +374,8 @@ steps:
       - { id: "#map_control.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_control.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_control.nthreads", source: "#nthreads_map" }
+      - { id: "#map_control.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_control.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_control.output_data_sorted_dedup_bam_files" }
       - { id: "#map_control.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
@@ -251,7 +251,7 @@ steps:
       - { id:  "#map.output_picard_mark_duplicates_files" }
       - { id:  "#map.output_pbc_files" }
   - id: "#peak_call"
-    run: {import: "04-peakcall-broad-.cwl" }
+    run: {import: "04-peakcall-broad.cwl" }
     inputs:
       - { id: "#peak_call.input_bam_files", source: "#map.output_data_sorted_dedup_bam_files" }
       - { id: "#peak_call.input_bam_format", valueFrom: "BAMPE" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
@@ -39,6 +39,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
    - id: "#qc_count_raw_reads_read1"
     source: "#qc.output_count_raw_reads_read1"
@@ -211,6 +221,8 @@ steps:
       - { id: "#trimm.input_read1_adapters_files", source: "#qc.output_custom_adapters_read1" }
       - { id: "#trimm.input_read2_adapters_files", source: "#qc.output_custom_adapters_read2" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm.output_data_fastq_read2_trimmed_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-broad.cwl
@@ -40,15 +40,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
    - id: "#qc_count_raw_reads_read1"
     source: "#qc.output_count_raw_reads_read1"
@@ -237,6 +243,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
@@ -49,6 +49,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_treatment_count_raw_reads_read1"
     source: "#qc_treatment.output_count_raw_reads_read1"
@@ -293,6 +303,8 @@ steps:
       - { id: "#trimm_treatment.input_read1_adapters_files", source: "#qc_treatment.output_custom_adapters_read1" }
       - { id: "#trimm_treatment.input_read2_adapters_files", source: "#qc_treatment.output_custom_adapters_read2" }
       - { id: "#trimm_treatment.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_treatment.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_treatment.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm_treatment.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm_treatment.output_data_fastq_read2_trimmed_files" }
@@ -338,6 +350,8 @@ steps:
       - { id: "#trimm_control.input_read1_adapters_files", source: "#qc_control.output_custom_adapters_read1" }
       - { id: "#trimm_control.input_read2_adapters_files", source: "#qc_control.output_custom_adapters_read2" }
       - { id: "#trimm_control.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_control.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_control.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm_control.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm_control.output_data_fastq_read2_trimmed_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
@@ -50,15 +50,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_treatment_count_raw_reads_read1"
     source: "#qc_treatment.output_count_raw_reads_read1"
@@ -319,6 +325,8 @@ steps:
       - { id: "#map_treatment.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_treatment.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_treatment.nthreads", source: "#nthreads_map" }
+      - { id: "#map_treatment.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_treatment.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_treatment.output_data_sorted_dedup_bam_files" }
       - { id: "#map_treatment.output_index_dedup_bam_files" }
@@ -366,6 +374,8 @@ steps:
       - { id: "#map_control.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_control.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_control.nthreads", source: "#nthreads_map" }
+      - { id: "#map_control.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_control.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_control.output_data_sorted_dedup_bam_files" }
       - { id: "#map_control.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
@@ -39,6 +39,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
    - id: "#qc_count_raw_reads_read1"
     source: "#qc.output_count_raw_reads_read1"
@@ -211,6 +221,8 @@ steps:
       - { id: "#trimm.input_read1_adapters_files", source: "#qc.output_custom_adapters_read1" }
       - { id: "#trimm.input_read2_adapters_files", source: "#qc.output_custom_adapters_read2" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm.output_data_fastq_read2_trimmed_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
@@ -40,15 +40,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
    - id: "#qc_count_raw_reads_read1"
     source: "#qc.output_count_raw_reads_read1"
@@ -237,6 +243,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-pe-narrow.cwl
@@ -251,7 +251,7 @@ steps:
       - { id:  "#map.output_picard_mark_duplicates_files" }
       - { id:  "#map.output_pbc_files" }
   - id: "#peak_call"
-    run: {import: "04-peakcall-narrow-.cwl" }
+    run: {import: "04-peakcall-narrow.cwl" }
     inputs:
       - { id: "#peak_call.input_bam_files", source: "#map.output_data_sorted_dedup_bam_files" }
       - { id: "#peak_call.input_bam_format", valueFrom: "BAMPE" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-broad-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-broad-with-control.cwl
@@ -37,6 +37,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_treatment_raw_read_counts"
     source: "#qc_treatment.output_raw_read_counts"
@@ -213,6 +223,8 @@ steps:
       - { id: "#trimm_treatment.input_fastq_files", source: "#input_treatment_fastq_files" }
       - { id: "#trimm_treatment.input_adapters_files", source: "#qc_treatment.output_custom_adapters" }
       - { id: "#trimm_treatment.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_treatment.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_treatment.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id: "#trimm_treatment.output_data_fastq_trimmed_files" }
       - { id: "#trimm_treatment.trimmed_fastq_read_count" }
@@ -247,6 +259,8 @@ steps:
       - { id: "#trimm_control.input_fastq_files", source: "#input_control_fastq_files" }
       - { id: "#trimm_control.input_adapters_files", source: "#qc_control.output_custom_adapters" }
       - { id: "#trimm_control.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_control.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_control.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id: "#trimm_control.output_data_fastq_trimmed_files" }
       - { id: "#trimm_control.trimmed_fastq_read_count" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-broad-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-broad-with-control.cwl
@@ -38,15 +38,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_treatment_raw_read_counts"
     source: "#qc_treatment.output_raw_read_counts"
@@ -236,6 +242,8 @@ steps:
       - { id: "#map_treatment.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_treatment.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_treatment.nthreads", source: "#nthreads_map" }
+      - { id: "#map_treatment.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_treatment.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_treatment.output_data_sorted_dedup_bam_files" }
       - { id: "#map_treatment.output_index_dedup_bam_files" }
@@ -272,6 +280,8 @@ steps:
       - { id: "#map_control.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_control.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_control.nthreads", source: "#nthreads_map" }
+      - { id: "#map_control.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_control.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_control.output_data_sorted_dedup_bam_files" }
       - { id: "#map_control.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
@@ -33,6 +33,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_raw_read_counts"
     source: "#qc.output_raw_read_counts"
@@ -167,6 +177,8 @@ steps:
       - { id: "#trimm.input_fastq_files", source: "#input_fastq_files" }
       - { id: "#trimm.input_adapters_files", source: "#qc.output_custom_adapters" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_trimmed_files" }
       - { id:  "#trimm.trimmed_fastq_read_count" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
@@ -204,7 +204,7 @@ steps:
       - { id:  "#map.output_picard_mark_duplicates_files" }
       - { id:  "#map.output_pbc_files" }
   - id: "#peak_call"
-    run: {import: "04-peakcall-broad-.cwl" }
+    run: {import: "04-peakcall-broad.cwl" }
     inputs:
       - { id: "#peak_call.input_bam_files", source: "#map.output_data_sorted_dedup_bam_files" }
       - { id: "#peak_call.input_bam_format", valueFrom: "BAM" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-broad.cwl
@@ -34,15 +34,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_raw_read_counts"
     source: "#qc.output_raw_read_counts"
@@ -190,6 +196,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
@@ -37,6 +37,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_treatment_raw_read_counts"
     source: "#qc_treatment.output_raw_read_counts"
@@ -213,6 +223,8 @@ steps:
       - { id: "#trimm_treatment.input_fastq_files", source: "#input_treatment_fastq_files" }
       - { id: "#trimm_treatment.input_adapters_files", source: "#qc_treatment.output_custom_adapters" }
       - { id: "#trimm_treatment.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_treatment.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_treatment.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id: "#trimm_treatment.output_data_fastq_trimmed_files" }
       - { id: "#trimm_treatment.trimmed_fastq_read_count" }
@@ -247,6 +259,8 @@ steps:
       - { id: "#trimm_control.input_fastq_files", source: "#input_control_fastq_files" }
       - { id: "#trimm_control.input_adapters_files", source: "#qc_control.output_custom_adapters" }
       - { id: "#trimm_control.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_control.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_control.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id: "#trimm_control.output_data_fastq_trimmed_files" }
       - { id: "#trimm_control.trimmed_fastq_read_count" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
@@ -38,15 +38,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_treatment_raw_read_counts"
     source: "#qc_treatment.output_raw_read_counts"
@@ -236,6 +242,8 @@ steps:
       - { id: "#map_treatment.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_treatment.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_treatment.nthreads", source: "#nthreads_map" }
+      - { id: "#map_treatment.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_treatment.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_treatment.output_data_sorted_dedup_bam_files" }
       - { id: "#map_treatment.output_index_dedup_bam_files" }
@@ -272,6 +280,8 @@ steps:
       - { id: "#map_control.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_control.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_control.nthreads", source: "#nthreads_map" }
+      - { id: "#map_control.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_control.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_control.output_data_sorted_dedup_bam_files" }
       - { id: "#map_control.output_index_dedup_bam_files" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
@@ -33,6 +33,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
   - id: "#qc_raw_read_counts"
     source: "#qc.output_raw_read_counts"
@@ -167,6 +177,8 @@ steps:
       - { id: "#trimm.input_fastq_files", source: "#input_fastq_files" }
       - { id: "#trimm.input_adapters_files", source: "#qc.output_custom_adapters" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_trimmed_files" }
       - { id:  "#trimm.trimmed_fastq_read_count" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
@@ -204,7 +204,7 @@ steps:
       - { id:  "#map.output_picard_mark_duplicates_files" }
       - { id:  "#map.output_pbc_files" }
   - id: "#peak_call"
-    run: {import: "04-peakcall-narrow-.cwl" }
+    run: {import: "04-peakcall-narrow.cwl" }
     inputs:
       - { id: "#peak_call.input_bam_files", source: "#map.output_data_sorted_dedup_bam_files" }
       - { id: "#peak_call.input_bam_format", valueFrom: "BAM" }

--- a/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
+++ b/GGR_ChIP-seq_pipeline/pipeline-se-narrow.cwl
@@ -34,15 +34,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
   - id: "#qc_raw_read_counts"
     source: "#qc.output_raw_read_counts"
@@ -190,6 +196,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }

--- a/cwl-generator/templates/chipseq-pipeline.j2
+++ b/cwl-generator/templates/chipseq-pipeline.j2
@@ -68,7 +68,16 @@ inputs:
   - id: "#nthreads_map"
     type: int
     description: "Numbers of threads required for the 03-map step"
-
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
 outputs:
 {%  if "control" in sample_types %}
     {% for sample_type in sample_types %}
@@ -363,6 +372,8 @@ steps:
       - { id: "#trimm_{{ sample_type }}.input_read1_adapters_files", source: "#qc_{{ sample_type }}.output_custom_adapters_read1" }
       - { id: "#trimm_{{ sample_type }}.input_read2_adapters_files", source: "#qc_{{ sample_type }}.output_custom_adapters_read2" }
       - { id: "#trimm_{{ sample_type }}.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_{{ sample_type }}.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_{{ sample_type }}.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm_{{ sample_type }}.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm_{{ sample_type }}.output_data_fastq_read2_trimmed_files" }
@@ -401,6 +412,8 @@ steps:
       - { id: "#trimm_{{ sample_type }}.input_fastq_files", source: "#input_{{ sample_type }}_fastq_files" }
       - { id: "#trimm_{{ sample_type }}.input_adapters_files", source: "#qc_{{ sample_type }}.output_custom_adapters" }
       - { id: "#trimm_{{ sample_type }}.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm_{{ sample_type }}.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm_{{ sample_type }}.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id: "#trimm_{{ sample_type }}.output_data_fastq_trimmed_files" }
       - { id: "#trimm_{{ sample_type }}.trimmed_fastq_read_count" }
@@ -446,6 +459,8 @@ steps:
       - { id: "#trimm.input_read1_adapters_files", source: "#qc.output_custom_adapters_read1" }
       - { id: "#trimm.input_read2_adapters_files", source: "#qc.output_custom_adapters_read2" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_read1_trimmed_files" }
       - { id:  "#trimm.output_data_fastq_read2_trimmed_files" }
@@ -484,6 +499,8 @@ steps:
       - { id: "#trimm.input_fastq_files", source: "#input_fastq_files" }
       - { id: "#trimm.input_adapters_files", source: "#qc.output_custom_adapters" }
       - { id: "#trimm.nthreads", source: "#nthreads_trimm" }
+      - { id: "#trimm.trimmomatic_jar_path", source: "#trimmomatic_jar_path" }
+      - { id: "#trimm.trimmomatic_java_opts", source: "#trimmomatic_java_opts" }
     outputs:
       - { id:  "#trimm.output_data_fastq_trimmed_files" }
       - { id:  "#trimm.trimmed_fastq_read_count" }

--- a/cwl-generator/templates/chipseq-pipeline.j2
+++ b/cwl-generator/templates/chipseq-pipeline.j2
@@ -533,7 +533,7 @@ steps:
       - { id:  "#map.output_pbc_files" }
 {% endif %}
   - id: "#peak_call"
-    run: {import: "04-peakcall-{{ peak_type }}-{% if 'control' in sample_types %}with-control{% endif %}.cwl" }
+    run: {import: "04-peakcall-{{ peak_type }}{% if 'control' in sample_types %}-with-control{% endif %}.cwl" }
     inputs:
       - { id: "#peak_call.input_bam_files", source: "#map{% if 'control' in sample_types %}_treatment{% endif %}.output_data_sorted_dedup_bam_files" }
       - { id: "#peak_call.input_bam_format", valueFrom: "BAM{% if read_type == 'pe' %}PE{% endif %}" }

--- a/cwl-generator/templates/chipseq-pipeline.j2
+++ b/cwl-generator/templates/chipseq-pipeline.j2
@@ -69,15 +69,21 @@ inputs:
     type: int
     description: "Numbers of threads required for the 03-map step"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+  - id: "#picard_jar_path"
+    type: string
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
 outputs:
 {%  if "control" in sample_types %}
     {% for sample_type in sample_types %}
@@ -388,6 +394,8 @@ steps:
       - { id: "#map_{{ sample_type }}.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_{{ sample_type }}.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_{{ sample_type }}.nthreads", source: "#nthreads_map" }
+      - { id: "#map_{{ sample_type }}.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_{{ sample_type }}.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_{{ sample_type }}.output_data_sorted_dedup_bam_files" }
       - { id: "#map_{{ sample_type }}.output_index_dedup_bam_files" }
@@ -425,6 +433,8 @@ steps:
       - { id: "#map_{{ sample_type }}.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map_{{ sample_type }}.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map_{{ sample_type }}.nthreads", source: "#nthreads_map" }
+      - { id: "#map_{{ sample_type }}.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map_{{ sample_type }}.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id: "#map_{{ sample_type }}.output_data_sorted_dedup_bam_files" }
       - { id: "#map_{{ sample_type }}.output_index_dedup_bam_files" }
@@ -475,6 +485,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }
@@ -512,6 +524,8 @@ steps:
       - { id: "#map.genome_sizes_file", source: "#genome_sizes_file" }
       - { id: "#map.ENCODE_blacklist_bedfile", source: "#ENCODE_blacklist_bedfile" }
       - { id: "#map.nthreads", source: "#nthreads_map" }
+      - { id: "#map.picard_jar_path", source: "#picard_jar_path" }
+      - { id: "#map.picard_java_opts", source: "#picard_java_opts" }
     outputs:
       - { id:  "#map.output_data_sorted_dedup_bam_files" }
       - { id:  "#map.output_index_dedup_bam_files" }

--- a/map/picard-MarkDuplicates.cwl
+++ b/map/picard-MarkDuplicates.cwl
@@ -22,22 +22,17 @@ inputs:
   - id: "#output_filename"
     type: string
     description: "Output filename used as basename"
-      
-  - id: "#java_Xms"
-    type: string
-    description: "Starting memory allocation pool for a Java Virtual Machine (JVM)"
-    default: "-Xms512m"
+  - id: "#java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
     inputBinding:
       position: 1
-  - id: "#java_Xmx"
+      shellQuote: false
+  - id: "#picard_jar_path"
     type: string
-    description: "Maximum memory allocation pool for a Java Virtual Machine (JVM)"
-    default: "-Xmx2000m"
-    inputBinding:
-      position: 1
-  - id: "#absolute_path_to_picard_jar"
-    type: string
-    description: 'Absolute path to the picard.jar file (Required for compatibility with docker)'
+    description: 'Path to the picard.jar file'
     inputBinding:
       position: 2
       prefix: "-jar"
@@ -77,3 +72,17 @@ arguments:
   - valueFrom: $('METRICS_FILE='+inputs.output_filename + '.' + inputs.metrics_suffix)
     position: 5
     shellQuote: false
+
+  - id: "#trimmomatic_jar_path"
+    type: string
+    inputBinding:
+      position: 2
+      prefix: "-jar"
+  - id: "#java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
+    inputBinding:
+      position: 1
+      shellQuote: false

--- a/map/picard-MarkDuplicates.cwl
+++ b/map/picard-MarkDuplicates.cwl
@@ -72,17 +72,3 @@ arguments:
   - valueFrom: $('METRICS_FILE='+inputs.output_filename + '.' + inputs.metrics_suffix)
     position: 5
     shellQuote: false
-
-  - id: "#trimmomatic_jar_path"
-    type: string
-    inputBinding:
-      position: 2
-      prefix: "-jar"
-  - id: "#java_opts"
-    type:
-      - 'null'
-      - string
-    description: "JVM arguments should be a quoted, space separated list"
-    inputBinding:
-      position: 1
-      shellQuote: false

--- a/trimmomatic/trimmomatic-pe.cwl
+++ b/trimmomatic/trimmomatic-pe.cwl
@@ -41,7 +41,7 @@ inputs:
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
     inputBinding:
       position: 1
       shellQuote: false

--- a/trimmomatic/trimmomatic-pe.cwl
+++ b/trimmomatic/trimmomatic-pe.cwl
@@ -6,28 +6,45 @@ hints:
   - class: DockerRequirement
     dockerImageId: 'dukegcb/trimmomatic'
 
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
 inputs:
-  - id: "#threads"
+  - id: "#nthreads"
     type: int
     default: 1
     inputBinding:
-      position: 1
+      position: 4
       prefix: -threads
   - id: "#quality_score"
     type: string
     default: "-phred33" # or "-phred64"
     inputBinding:
-      position: 2
+      position: 4
   - id: "#input_read1_fastq_file"
     type: File
     inputBinding:
-      position: 3
+      position: 5
   - id: "#input_read2_fastq_file"
     type: File
     inputBinding:
-      position: 4
+      position: 6
   - id: "#input_adapters_file"
     type: File
+  - id: "#trimmomatic_jar_path"
+    type: string
+    inputBinding:
+      position: 2
+      prefix: "-jar"
+  - id: "#java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
+    inputBinding:
+      position: 1
+      shellQuote: false
 
 outputs:
   - id: "#output_read1_trimmed_paired_file"
@@ -47,17 +64,21 @@ outputs:
     outputBinding:
       glob: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
 
-baseCommand: TrimmomaticPE
+baseCommand: java
 arguments:
+  - valueFrom: "PE"
+    position: 3
   - valueFrom: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
-    position: 5
-  - valueFrom: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
-    position: 6
-  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
     position: 7
-  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
     position: 8
-  - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
+  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
     position: 9
-  - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
+  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
     position: 10
+  - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
+    position: 11
+    shellQuote: false
+  - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
+    position: 12
+    shellQuote: false

--- a/trimmomatic/trimmomatic-se.cwl
+++ b/trimmomatic/trimmomatic-se.cwl
@@ -37,7 +37,7 @@ inputs:
     type:
       - 'null'
       - string
-    description: "JVM arguments should be a quoted, space separated list"
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
     inputBinding:
       position: 1
       shellQuote: false

--- a/trimmomatic/trimmomatic-se.cwl
+++ b/trimmomatic/trimmomatic-se.cwl
@@ -6,24 +6,41 @@ hints:
   - class: DockerRequirement
     dockerImageId: 'dukegcb/trimmomatic'
 
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+
 inputs:
   - id: "#nthreads"
     type: int
     default: 1
     inputBinding:
-      position: 1
+      position: 4
       prefix: -threads
   - id: "#quality_score"
     type: string
     default: "-phred33" # or "-phred64"
     inputBinding:
-      position: 2
+      position: 4
   - id: "#input_fastq_file"
     type: File
     inputBinding:
-      position: 3
+      position: 5
   - id: "#input_adapters_file"
     type: File
+  - id: "#trimmomatic_jar_path"
+    type: string
+    inputBinding:
+      position: 2
+      prefix: "-jar"
+  - id: "#java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
+    inputBinding:
+      position: 1
+      shellQuote: false
 
 
 outputs:
@@ -32,11 +49,15 @@ outputs:
     outputBinding:
       glob: $(inputs.input_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.trimmed.fastq')
 
-baseCommand: TrimmomaticSE
+baseCommand: java
 arguments:
+  - valueFrom: "SE"
+    position: 3
   - valueFrom: $(inputs.input_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.trimmed.fastq')
-    position: 4
-  - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
-    position: 5
-  - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
     position: 6
+  - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
+    position: 7
+    shellQuote: false
+  - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
+    position: 8
+    shellQuote: false


### PR DESCRIPTION
Various adjustments made after testing in HARDAC. Noteworthy, for Java tools I decided to populate the path to the jar file as a string. The wrapper script solution would, again, be host dependent and in some ways it feels more obscure to the final user of the workflows. By default, the pipelines use the paths to the jars in the Docker tool images, which makes them only needed outside the container.  I found this to be actually more user friendly than a wrapper script that needs to be tweaked it. 