### PR TITLE
CWL generators for the peakcall, map, trim and qc workflows

### DIFF
--- a/GGR_ChIP-seq_pipeline/01-qc-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/01-qc-pe.cwl
@@ -1,10 +1,8 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - QC PE"
+description: "GGR_ChIP-seq 01 QC - reads: PE"
 requirements:
   - class: ScatterFeatureRequirement
-
 inputs:
   - id: "#input_read1_fastq_files"
     type:
@@ -22,7 +20,6 @@ inputs:
   - id: "#nthreads"
     description: "Number of threads."
     type: int
-
 outputs:
   - id: "#output_fastqc_report_files_read1"
     source: "#fastqc_read1.output_qc_report_file"
@@ -95,7 +92,6 @@ steps:
         source: "#input_read2_fastq_files"
     outputs:
       - id: "#extract_basename_read2.output_basename"
-
   - id: "#count_raw_reads_read1"
     run: {import: "../utils/count-fastq-reads.cwl" }
     scatter:
@@ -109,7 +105,6 @@ steps:
         source: "#extract_basename_read1.output_basename"
     outputs:
       - id: "#count_raw_reads_read1.output_read_count"
-
   - id: "#count_raw_reads_read2"
     run: {import: "../utils/count-fastq-reads.cwl" }
     scatter:
@@ -123,7 +118,6 @@ steps:
         source: "#extract_basename_read2.output_basename"
     outputs:
       - id: "#count_raw_reads_read2.output_read_count"
-
   - id: "#fastqc_read1"
     run: {import: "../qc/fastqc.cwl" }
     scatter: "#fastqc_read1.input_fastq_file"
@@ -144,7 +138,6 @@ steps:
         source: "#nthreads"
     outputs:
       - id: "#fastqc_read2.output_qc_report_file"
-
   - id: "#extract_fastqc_data_read1"
     run: {import: "../qc/extract_fastqc_data.cwl" }
     scatter:
@@ -158,7 +151,6 @@ steps:
         source: "#extract_basename_read1.output_basename"
     outputs:
       - id: "#extract_fastqc_data_read1.output_fastqc_data_file"
-
   - id: "#extract_fastqc_data_read2"
     run: {import: "../qc/extract_fastqc_data.cwl" }
     scatter:
@@ -172,7 +164,6 @@ steps:
         source: "#extract_basename_read2.output_basename"
     outputs:
       - id: "#extract_fastqc_data_read2.output_fastqc_data_file"
-
   - id: "#overrepresented_sequence_extract_read1"
     run: {import: "../qc/overrepresented_sequence_extract.cwl" }
     scatter:
@@ -188,7 +179,6 @@ steps:
         source: "#extract_basename_read1.output_basename"
     outputs:
       - id: "#overrepresented_sequence_extract_read1.output_custom_adapters"
-
   - id: "#overrepresented_sequence_extract_read2"
     run: {import: "../qc/overrepresented_sequence_extract.cwl" }
     scatter:
@@ -204,7 +194,6 @@ steps:
         source: "#extract_basename_read2.output_basename"
     outputs:
       - id: "#overrepresented_sequence_extract_read2.output_custom_adapters"
-
   - id: "#count_fastqc_reads_read1"
     run: {import: "../qc/count-fastqc-reads.cwl" }
     scatter:
@@ -218,7 +207,6 @@ steps:
         source: "#extract_basename_read1.output_basename"
     outputs:
       - id: "#count_fastqc_reads_read1.output_fastqc_read_count"
-
   - id: "#count_fastqc_reads_read2"
     run: {import: "../qc/count-fastqc-reads.cwl" }
     scatter:
@@ -232,7 +220,6 @@ steps:
         source: "#extract_basename_read2.output_basename"
     outputs:
       - id: "#count_fastqc_reads_read2.output_fastqc_read_count"
-
   - id: "#compare_read_counts_read1"
     run: {import: "../qc/diff.cwl" }
     scatter:
@@ -246,7 +233,6 @@ steps:
         source: "#count_fastqc_reads_read1.output_fastqc_read_count"
     outputs:
       - id: "#compare_read_counts_read1.result"
-
   - id: "#compare_read_counts_read2"
     run: {import: "../qc/diff.cwl" }
     scatter:

--- a/GGR_ChIP-seq_pipeline/01-qc-se.cwl
+++ b/GGR_ChIP-seq_pipeline/01-qc-se.cwl
@@ -1,10 +1,8 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - QC"
+description: "GGR_ChIP-seq 01 QC - reads: SE"
 requirements:
   - class: ScatterFeatureRequirement
-
 inputs:
   - id: "#input_fastq_files"
     type:
@@ -17,7 +15,6 @@ inputs:
   - id: "#nthreads"
     description: "Number of threads."
     type: int
-
 outputs:
   - id: "#output_raw_read_counts"
     source: "#count_raw_reads.output_read_count"
@@ -47,7 +44,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#extract_basename"
     run: {import: "../utils/extract-basename.cwl" }

--- a/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
@@ -1,13 +1,11 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - Trimm"
+description: "GGR_ChIP-seq 02 trimming - reads: PE"
 requirements:
   - class: ScatterFeatureRequirement
-
 inputs:
   - id: "#input_read1_fastq_files"
-    type: 
+    type:
       type: array
       items: File
     description: "Input read 1 fastq files"
@@ -44,7 +42,6 @@ inputs:
       - 'null'
       - string
     description: "JVM arguments should be a quoted, space separated list"
-
 outputs:
   - id: "#output_data_fastq_read1_trimmed_files"
     source: "#trimmomatic-pe.output_read1_trimmed_paired_file"
@@ -70,7 +67,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#concat_adapters"
     run: {import: "../utils/concat-files.cwl"}

--- a/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-pe.cwl
@@ -32,9 +32,7 @@ inputs:
     type: string
     default: "-phred33"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     default: "/usr/share/java/trimmomatic.jar"
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"

--- a/GGR_ChIP-seq_pipeline/02-trim-se.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-se.cwl
@@ -1,13 +1,11 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - Trimm"
+description: "GGR_ChIP-seq 02 trimming - reads: SE"
 requirements:
   - class: ScatterFeatureRequirement
-
 inputs:
   - id: "#input_fastq_files"
-    type: 
+    type:
       type: array
       items: File
     description: "Input fastq files"
@@ -19,6 +17,10 @@ inputs:
   - id: "#nthreads"
     type: int
     default: 1
+    description: "Number of threads"
+  - id: "#quality_score"
+    type: string
+    default: "-phred33"
   - id: "#trimmomatic_jar_path"
     type:
       - 'null'
@@ -30,7 +32,6 @@ inputs:
       - 'null'
       - string
     description: "JVM arguments should be a quoted, space separated list"
-
 outputs:
   - id: "#output_data_fastq_trimmed_files"
     source: "#trimmomatic-se.output_trimmed_file"
@@ -44,7 +45,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#trimmomatic-se"
     run: {import: "../trimmomatic/trimmomatic-se.cwl"}

--- a/GGR_ChIP-seq_pipeline/02-trim-se.cwl
+++ b/GGR_ChIP-seq_pipeline/02-trim-se.cwl
@@ -22,9 +22,7 @@ inputs:
     type: string
     default: "-phred33"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     default: "/usr/share/java/trimmomatic.jar"
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"

--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -1,15 +1,12 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - Mapping"
-
+description: "GGR_ChIP-peq 03 mapping - reads: PE"
 requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement
-
 inputs:
   - id: "#input_fastq_read1_files"
-    type: 
+    type:
       type: array
       items: File
     description: "Input fastq paired-end read 1 files"
@@ -39,7 +36,6 @@ inputs:
       - 'null'
       - string
     description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
-
 outputs:
   - id: "#output_picard_mark_duplicates_files"
     source: "#remove_duplicates.output_metrics_file"
@@ -83,7 +79,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#extract_basename_1"
     run: {import: "../utils/extract-basename.cwl" }
@@ -115,7 +110,7 @@ steps:
         source: "#input_fastq_read2_files"
       - id: "#bowtie-pe.output_filename"
         source: "#extract_basename_2.output_path"
-      - id: "#bowtie-se.genome_ref_first_index_file"
+      - id: "#bowtie-pe.genome_ref_first_index_file"
         source: "#genome_ref_first_index_file"
       - id: "#bowtie-pe.nthreads"
         source: "#nthreads"

--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 class: Workflow
-description: "GGR_ChIP-peq 03 mapping - reads: PE"
+description: "GGR_ChIP-seq 03 mapping - reads: PE"
 requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -1,21 +1,18 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - Mapping"
-
+description: "GGR_ChIP-seq 03 mapping - reads: SE"
 requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement
-
 inputs:
   - id: "#input_fastq_files"
-    type: 
+    type:
       type: array
       items: File
     description: "Input fastq files"
   - id: "#genome_ref_first_index_file"
     type: File
-    description: "Bowtie first index files for reference genome (*1.ebwt). The rest of the files should be in the same folder."
+    description: "Bowtie first index files for reference genome (e.g. *1.ebwt). The rest of the files should be in the same folder."
   - id: "#genome_sizes_file"
     type: File
     description: "Genome sizes tab-delimited file (used in samtools)"
@@ -34,14 +31,7 @@ inputs:
       - 'null'
       - string
     description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
-
 outputs:
-  - id: "#output_sorted_dedup_bam_files"
-    source: "#filtered2sorted.sorted_file"
-    description: "Filtered sorted aligned BAM files with Bowtie."
-    type:
-      type: array
-      items: File
   - id: "#output_picard_mark_duplicates_files"
     source: "#remove_duplicates.output_metrics_file"
     description: "Picard MarkDuplicates metrics files."
@@ -84,7 +74,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#extract_basename_1"
     run: {import: "../utils/extract-basename.cwl" }
@@ -115,7 +104,7 @@ steps:
         source: "#extract_basename_2.output_path"
       - id: "#bowtie-se.genome_ref_first_index_file"
         source: "#genome_ref_first_index_file"
-      - id: "bowtie-se.nthreads"
+      - id: "#bowtie-se.nthreads"
         source: "#nthreads"
     outputs:
       - id: "#bowtie-se.output_aligned_file"

--- a/GGR_ChIP-seq_pipeline/04-peakcall-broad-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/04-peakcall-broad-with-control.cwl
@@ -1,17 +1,11 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - processing step 2 - Peak calling for broad peaks with control samples (SE)"
-
+description: "GGR_ChIP-seq 04 quantification - region: broad, samples: treatment and control."
 requirements:
   - class: ScatterFeatureRequirement
-
+  - class: StepInputExpressionRequirement
 inputs:
   - id: "#input_bam_files"
-    type:
-      type: array
-      items: File
-  - id: "#input_control_bam_files"
     type:
       type: array
       items: File
@@ -19,7 +13,13 @@ inputs:
     type: string
     description: "BAM or BAMPE for single-end and paired-end reads respectively (default: BAM)"
     default: "BAM"
-
+  - id: "#input_control_bam_files"
+    type:
+      type: array
+      items: File
+  - id: "#nthreads"
+    type: int
+    default: 1
 outputs:
   - id: "#output_spp_x_cross_corr"
     source: "#spp.output_spp_cross_corr"
@@ -69,7 +69,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#spp"
     run: {import: "../spp/spp-with-control.cwl"}
@@ -85,7 +84,7 @@ steps:
       - id: "#spp.savp"
         default: True
       - id: "#spp.nthreads"
-        default: 1
+        source: "#nthreads"
     outputs:
       - id: "#spp.output_spp_cross_corr"
       - id: "#spp.output_spp_cross_corr_plot"
@@ -134,7 +133,7 @@ steps:
       - id: "#count-peaks.input_file"
         source: "#peak-calling-broad.output_broadpeak_file"
       - id: "#count-peaks.output_suffix"
-        default: ".peak_count.within_replicate.txt"
+        valueFrom: ".peak_count.within_replicate.txt"
     outputs:
       - id: "#count-peaks.output_counts"
   - id: "#filter-reads-in-peaks"
@@ -157,6 +156,6 @@ steps:
       - id: "#extract-count-reads-in-peaks.input_bam_file"
         source: "#filter-reads-in-peaks.filtered_file"
       - id: "#extract-count-reads-in-peaks.output_suffix"
-        default: ".read_count.within_replicate.txt"
+        valueFrom: ".read_count.within_replicate.txt"
     outputs:
       - id: "#extract-count-reads-in-peaks.output_read_count"

--- a/GGR_ChIP-seq_pipeline/04-peakcall-broad.cwl
+++ b/GGR_ChIP-seq_pipeline/04-peakcall-broad.cwl
@@ -1,12 +1,9 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - processing step 2 - Peak calling for broad peaks (SE)"
-
+description: "GGR_ChIP-seq 04 quantification - region: broad, samples: treatment."
 requirements:
   - class: ScatterFeatureRequirement
   - class: StepInputExpressionRequirement
-
 inputs:
   - id: "#input_bam_files"
     type:
@@ -16,7 +13,9 @@ inputs:
     type: string
     description: "BAM or BAMPE for single-end and paired-end reads respectively (default: BAM)"
     default: "BAM"
-
+  - id: "#nthreads"
+    type: int
+    default: 1
 outputs:
   - id: "#output_spp_x_cross_corr"
     source: "#spp.output_spp_cross_corr"
@@ -66,18 +65,19 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#spp"
     run: {import: "../spp/spp.cwl"}
-    scatter: "#spp.input_bam"
+    scatter:
+      - "#spp.input_bam"
+    scatterMethod: dotproduct
     inputs:
       - id: "#spp.input_bam"
         source: "#input_bam_files"
       - id: "#spp.savp"
         default: True
       - id: "#spp.nthreads"
-        default: 1
+        source: "#nthreads"
     outputs:
       - id: "#spp.output_spp_cross_corr"
       - id: "#spp.output_spp_cross_corr_plot"
@@ -89,7 +89,6 @@ steps:
         source: "#spp.output_spp_cross_corr"
     outputs:
       - id: "#extract-peak-frag-length.output_best_frag_length"
-
   - id: "#peak-calling-broad"
     run: {import: "../peak_calling/macs2-callpeak-broad.cwl"}
     scatter:

--- a/GGR_ChIP-seq_pipeline/04-peakcall-narrow-with-control.cwl
+++ b/GGR_ChIP-seq_pipeline/04-peakcall-narrow-with-control.cwl
@@ -1,17 +1,11 @@
 #!/usr/bin/env cwl-runner
-
 class: Workflow
-description: "GGR_ChIP-seq - processing step 2 - Peak calling for narrow peaks with control samples (SE)"
-
+description: "GGR_ChIP-seq 04 quantification - region: narrow, samples: treatment and control."
 requirements:
   - class: ScatterFeatureRequirement
-
+  - class: StepInputExpressionRequirement
 inputs:
   - id: "#input_bam_files"
-    type:
-      type: array
-      items: File
-  - id: "#input_control_bam_files"
     type:
       type: array
       items: File
@@ -19,7 +13,13 @@ inputs:
     type: string
     description: "BAM or BAMPE for single-end and paired-end reads respectively (default: BAM)"
     default: "BAM"
-
+  - id: "#input_control_bam_files"
+    type:
+      type: array
+      items: File
+  - id: "#nthreads"
+    type: int
+    default: 1
 outputs:
   - id: "#output_spp_x_cross_corr"
     source: "#spp.output_spp_cross_corr"
@@ -69,7 +69,6 @@ outputs:
     type:
       type: array
       items: File
-
 steps:
   - id: "#spp"
     run: {import: "../spp/spp-with-control.cwl"}
@@ -85,7 +84,7 @@ steps:
       - id: "#spp.savp"
         default: True
       - id: "#spp.nthreads"
-        default: 1
+        source: "#nthreads"
     outputs:
       - id: "#spp.output_spp_cross_corr"
       - id: "#spp.output_spp_cross_corr_plot"
@@ -134,7 +133,7 @@ steps:
       - id: "#count-peaks.input_file"
         source: "#peak-calling-narrow.output_narrowpeak_file"
       - id: "#count-peaks.output_suffix"
-        default: ".peak_count.within_replicate.txt"
+        valueFrom: ".peak_count.within_replicate.txt"
     outputs:
       - id: "#count-peaks.output_counts"
   - id: "#filter-reads-in-peaks"
@@ -157,6 +156,6 @@ steps:
       - id: "#extract-count-reads-in-peaks.input_bam_file"
         source: "#filter-reads-in-peaks.filtered_file"
       - id: "#extract-count-reads-in-peaks.output_suffix"
-        default: ".read_count.within_replicate.txt"
+        valueFrom: ".read_count.within_replicate.txt"
     outputs:
       - id: "#extract-count-reads-in-peaks.output_read_count"

--- a/cwl-generator/run.py
+++ b/cwl-generator/run.py
@@ -20,6 +20,8 @@ def get_cwl_name(template_name, conf_obj):
         return "04-peakcall-%s" % '-'.join(suf_list)
     if 'chipseq-03-map' == template_name:
         return "03-map-%s" % conf_obj['read_type']
+    if 'chipseq-02-trim' == template_name:
+        return "02-trim-%s" % conf_obj['read_type']
     return None
 
 

--- a/cwl-generator/run.py
+++ b/cwl-generator/run.py
@@ -12,6 +12,12 @@ def get_cwl_name(template_name, conf_obj):
         else:
             suf_list = [conf_obj['read_type'], conf_obj['peak_type'], 'with-control']
         return "pipeline-%s" % '-'.join(suf_list)
+    if 'chipseq-04-peakcall' == template_name:
+        if "control" not in conf_obj['sample_types']:
+            suf_list = [conf_obj['peak_type']]
+        else:
+            suf_list = [conf_obj['peak_type'], 'with-control']
+        return "04-peakcall-%s" % '-'.join(suf_list)
     return None
 
 

--- a/cwl-generator/run.py
+++ b/cwl-generator/run.py
@@ -22,6 +22,8 @@ def get_cwl_name(template_name, conf_obj):
         return "03-map-%s" % conf_obj['read_type']
     if 'chipseq-02-trim' == template_name:
         return "02-trim-%s" % conf_obj['read_type']
+    if 'chipseq-01-qc' == template_name:
+        return "01-qc-%s" % conf_obj['read_type']
     return None
 
 

--- a/cwl-generator/run.py
+++ b/cwl-generator/run.py
@@ -18,6 +18,8 @@ def get_cwl_name(template_name, conf_obj):
         else:
             suf_list = [conf_obj['peak_type'], 'with-control']
         return "04-peakcall-%s" % '-'.join(suf_list)
+    if 'chipseq-03-map' == template_name:
+        return "03-map-%s" % conf_obj['read_type']
     return None
 
 

--- a/cwl-generator/templates/chipseq-01-qc.j2
+++ b/cwl-generator/templates/chipseq-01-qc.j2
@@ -1,0 +1,392 @@
+#!/usr/bin/env cwl-runner
+
+class: Workflow
+description: "GGR_ChIP-seq 01 QC - reads: {{read_type|upper}}"
+
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+{% if read_type == "pe" %}
+  - id: "#input_read1_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input read1 fastq files"
+  - id: "#input_read2_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input read2 fastq files"
+{% else %}
+  - id: "#input_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input fastq files"
+{% endif %}
+  - id: "#default_adapters_file"
+    type: File
+    description: "Adapters file"
+  - id: "#nthreads"
+    description: "Number of threads."
+    type: int
+
+outputs:
+{% if read_type == 'pe' %}
+  - id: "#output_fastqc_report_files_read1"
+    source: "#fastqc_read1.output_qc_report_file"
+    description: "FastQC reports in zip format for paired read 1"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_report_files_read2"
+    source: "#fastqc_read2.output_qc_report_file"
+    description: "FastQC reports in zip format for paired read 2"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_data_files_read1"
+    source: "#extract_fastqc_data_read1.output_fastqc_data_file"
+    description: "FastQC data files for paired read 1"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_data_files_read2"
+    source: "#extract_fastqc_data_read2.output_fastqc_data_file"
+    description: "FastQC data files for paired read 2"
+    type:
+      type: array
+      items: File
+  - id: "#output_custom_adapters_read1"
+    source: "#overrepresented_sequence_extract_read1.output_custom_adapters"
+    type:
+      type: array
+      items: File
+  - id: "#output_custom_adapters_read2"
+    source: "#overrepresented_sequence_extract_read2.output_custom_adapters"
+    type:
+      type: array
+      items: File
+  - id: "#output_count_raw_reads_read1"
+    source: "#count_raw_reads_read1.output_read_count"
+    type:
+      type: array
+      items: File
+  - id: "#output_count_raw_reads_read2"
+    source: "#count_raw_reads_read2.output_read_count"
+    type:
+      type: array
+      items: File
+  - id: "#output_diff_counts_read1"
+    source: "#compare_read_counts_read1.result"
+    type:
+      type: array
+      items: File
+  - id: "#output_diff_counts_read2"
+    source: "#compare_read_counts_read2.result"
+    type:
+      type: array
+      items: File
+{% else %}
+  - id: "#output_raw_read_counts"
+    source: "#count_raw_reads.output_read_count"
+    description: "Raw read counts of fastq files"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_read_counts"
+    source: "#count_fastqc_reads.output_fastqc_read_count"
+    description: "Read counts of fastq files from FastQC"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_report_files"
+    source: "#fastqc.output_qc_report_file"
+    description: "FastQC reports in zip format"
+    type:
+      type: array
+      items: File
+  - id: "#output_fastqc_data_files"
+    source: "#extract_fastqc_data.output_fastqc_data_file"
+    type:
+      type: array
+      items: File
+  - id: "#output_custom_adapters"
+    source: "#overrepresented_sequence_extract.output_custom_adapters"
+    type:
+      type: array
+      items: File
+{% endif %}
+
+steps:
+{% if read_type == 'pe' %}
+  - id: "#extract_basename_read1"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename_read1.input_file"
+    inputs:
+      - id: "#extract_basename_read1.input_file"
+        source: "#input_read1_fastq_files"
+    outputs:
+      - id: "#extract_basename_read1.output_basename"
+  - id: "#extract_basename_read2"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename_read2.input_file"
+    inputs:
+      - id: "#extract_basename_read2.input_file"
+        source: "#input_read2_fastq_files"
+    outputs:
+      - id: "#extract_basename_read2.output_basename"
+
+  - id: "#count_raw_reads_read1"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_raw_reads_read1.input_fastq_file"
+      - "#count_raw_reads_read1.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_raw_reads_read1.input_fastq_file"
+        source: "#input_read1_fastq_files"
+      - id: "#count_raw_reads_read1.input_basename"
+        source: "#extract_basename_read1.output_basename"
+    outputs:
+      - id: "#count_raw_reads_read1.output_read_count"
+
+  - id: "#count_raw_reads_read2"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_raw_reads_read2.input_fastq_file"
+      - "#count_raw_reads_read2.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_raw_reads_read2.input_fastq_file"
+        source: "#input_read2_fastq_files"
+      - id: "#count_raw_reads_read2.input_basename"
+        source: "#extract_basename_read2.output_basename"
+    outputs:
+      - id: "#count_raw_reads_read2.output_read_count"
+
+  - id: "#fastqc_read1"
+    run: {import: "../qc/fastqc.cwl" }
+    scatter: "#fastqc_read1.input_fastq_file"
+    inputs:
+      - id: "#fastqc_read1.input_fastq_file"
+        source: "#input_read1_fastq_files"
+      - id: "#fastqc.threads"
+        source: "#nthreads"
+    outputs:
+      - id: "#fastqc_read1.output_qc_report_file"
+  - id: "#fastqc_read2"
+    run: {import: "../qc/fastqc.cwl" }
+    scatter: "#fastqc_read2.input_fastq_file"
+    inputs:
+      - id: "#fastqc_read2.input_fastq_file"
+        source: "#input_read2_fastq_files"
+      - id: "#fastqc.threads"
+        source: "#nthreads"
+    outputs:
+      - id: "#fastqc_read2.output_qc_report_file"
+
+  - id: "#extract_fastqc_data_read1"
+    run: {import: "../qc/extract_fastqc_data.cwl" }
+    scatter:
+      - "#extract_fastqc_data_read1.input_qc_report_file"
+      - "#extract_fastqc_data_read1.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#extract_fastqc_data_read1.input_qc_report_file"
+        source: "#fastqc_read1.output_qc_report_file"
+      - id: "#extract_fastqc_data_read1.input_basename"
+        source: "#extract_basename_read1.output_basename"
+    outputs:
+      - id: "#extract_fastqc_data_read1.output_fastqc_data_file"
+
+  - id: "#extract_fastqc_data_read2"
+    run: {import: "../qc/extract_fastqc_data.cwl" }
+    scatter:
+      - "#extract_fastqc_data_read2.input_qc_report_file"
+      - "#extract_fastqc_data_read2.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#extract_fastqc_data_read2.input_qc_report_file"
+        source: "#fastqc_read1.output_qc_report_file"
+      - id: "#extract_fastqc_data_read2.input_basename"
+        source: "#extract_basename_read2.output_basename"
+    outputs:
+      - id: "#extract_fastqc_data_read2.output_fastqc_data_file"
+
+  - id: "#overrepresented_sequence_extract_read1"
+    run: {import: "../qc/overrepresented_sequence_extract.cwl" }
+    scatter:
+      - "#overrepresented_sequence_extract_read1.input_fastqc_data"
+      - "#overrepresented_sequence_extract_read1.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#overrepresented_sequence_extract_read1.input_fastqc_data"
+        source: "#extract_fastqc_data_read1.output_fastqc_data_file"
+      - id: "#overrepresented_sequence_extract_read1.default_adapters_file"
+        source: "#default_adapters_file"
+      - id: "#overrepresented_sequence_extract_read1.input_basename"
+        source: "#extract_basename_read1.output_basename"
+    outputs:
+      - id: "#overrepresented_sequence_extract_read1.output_custom_adapters"
+
+  - id: "#overrepresented_sequence_extract_read2"
+    run: {import: "../qc/overrepresented_sequence_extract.cwl" }
+    scatter:
+      - "#overrepresented_sequence_extract_read2.input_fastqc_data"
+      - "#overrepresented_sequence_extract_read2.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#overrepresented_sequence_extract_read2.input_fastqc_data"
+        source: "#extract_fastqc_data_read2.output_fastqc_data_file"
+      - id: "#overrepresented_sequence_extract_read2.default_adapters_file"
+        source: "#default_adapters_file"
+      - id: "#overrepresented_sequence_extract_read2.input_basename"
+        source: "#extract_basename_read2.output_basename"
+    outputs:
+      - id: "#overrepresented_sequence_extract_read2.output_custom_adapters"
+
+  - id: "#count_fastqc_reads_read1"
+    run: {import: "../qc/count-fastqc-reads.cwl" }
+    scatter:
+      - "#count_fastqc_reads_read1.input_fastqc_data"
+      - "#count_fastqc_reads_read1.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastqc_reads_read1.input_fastqc_data"
+        source: "#extract_fastqc_data_read1.output_fastqc_data_file"
+      - id: "#count_fastqc_reads_read1.input_basename"
+        source: "#extract_basename_read1.output_basename"
+    outputs:
+      - id: "#count_fastqc_reads_read1.output_fastqc_read_count"
+
+  - id: "#count_fastqc_reads_read2"
+    run: {import: "../qc/count-fastqc-reads.cwl" }
+    scatter:
+      - "#count_fastqc_reads_read2.input_fastqc_data"
+      - "#count_fastqc_reads_read2.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastqc_reads_read2.input_fastqc_data"
+        source: "#extract_fastqc_data_read2.output_fastqc_data_file"
+      - id: "#count_fastqc_reads_read2.input_basename"
+        source: "#extract_basename_read2.output_basename"
+    outputs:
+      - id: "#count_fastqc_reads_read2.output_fastqc_read_count"
+
+  - id: "#compare_read_counts_read1"
+    run: {import: "../qc/diff.cwl" }
+    scatter:
+      - "#compare_read_counts_read1.file1"
+      - "#compare_read_counts_read1.file2"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#compare_read_counts_read1.file1"
+        source: "#count_raw_reads_read1.output_read_count"
+      - id: "#compare_read_counts_read1.file2"
+        source: "#count_fastqc_reads_read1.output_fastqc_read_count"
+    outputs:
+      - id: "#compare_read_counts_read1.result"
+
+  - id: "#compare_read_counts_read2"
+    run: {import: "../qc/diff.cwl" }
+    scatter:
+      - "#compare_read_counts_read2.file1"
+      - "#compare_read_counts_read2.file2"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#compare_read_counts_read2.file1"
+        source: "#count_raw_reads_read2.output_read_count"
+      - id: "#compare_read_counts_read2.file2"
+        source: "#count_fastqc_reads_read2.output_fastqc_read_count"
+    outputs:
+      - id: "#compare_read_counts_read2.result"
+{% else %}
+  - id: "#extract_basename"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename.input_file"
+    inputs:
+      - id: "#extract_basename.input_file"
+        source: "#input_fastq_files"
+    outputs:
+      - id: "#extract_basename.output_basename"
+  - id: "#count_raw_reads"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_raw_reads.input_fastq_file"
+      - "#count_raw_reads.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_raw_reads.input_fastq_file"
+        source: "#input_fastq_files"
+      - id: "#count_raw_reads.input_basename"
+        source: "#extract_basename.output_basename"
+    outputs:
+      - id: "#count_raw_reads.output_read_count"
+  - id: "#fastqc"
+    run: {import: "../qc/fastqc.cwl" }
+    scatter: "#fastqc.input_fastq_file"
+    inputs:
+      - id: "#fastqc.input_fastq_file"
+        source: "#input_fastq_files"
+      - id: "#fastqc.threads"
+        source: "#nthreads"
+    outputs:
+      - id: "#fastqc.output_qc_report_file"
+  - id: "#extract_fastqc_data"
+    run: {import: "../qc/extract_fastqc_data.cwl" }
+    scatter:
+      - "#extract_fastqc_data.input_qc_report_file"
+      - "#extract_fastqc_data.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#extract_fastqc_data.input_qc_report_file"
+        source: "#fastqc.output_qc_report_file"
+      - id: "#extract_fastqc_data.input_basename"
+        source: "#extract_basename.output_basename"
+    outputs:
+      - id: "#extract_fastqc_data.output_fastqc_data_file"
+  - id: "#overrepresented_sequence_extract"
+    run: {import: "../qc/overrepresented_sequence_extract.cwl" }
+    scatter:
+      - "#overrepresented_sequence_extract.input_fastqc_data"
+      - "#overrepresented_sequence_extract.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#overrepresented_sequence_extract.input_fastqc_data"
+        source: "#extract_fastqc_data.output_fastqc_data_file"
+      - id: "#overrepresented_sequence_extract.default_adapters_file"
+        source: "#default_adapters_file"
+      - id: "#overrepresented_sequence_extract.input_basename"
+        source: "#extract_basename.output_basename"
+    outputs:
+      - id: "#overrepresented_sequence_extract.output_custom_adapters"
+  - id: "#count_fastqc_reads"
+    run: {import: "../qc/count-fastqc-reads.cwl" }
+    scatter:
+      - "#count_fastqc_reads.input_fastqc_data"
+      - "#count_fastqc_reads.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastqc_reads.input_fastqc_data"
+        source: "#extract_fastqc_data.output_fastqc_data_file"
+      - id: "#count_fastqc_reads.input_basename"
+        source: "#extract_basename.output_basename"
+    outputs:
+      - id: "#count_fastqc_reads.output_fastqc_read_count"
+  - id: "#compare_read_counts"
+    run: {import: "../qc/diff.cwl" }
+    scatter:
+      - "#compare_read_counts.file1"
+      - "#compare_read_counts.file2"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#compare_read_counts.file1"
+        source: "#count_raw_reads.output_read_count"
+      - id: "#compare_read_counts.file2"
+        source: "#count_fastqc_reads.output_fastqc_read_count"
+    outputs:
+      - id: "#compare_read_counts.result"
+{% endif %}
+

--- a/cwl-generator/templates/chipseq-02-trim.j2
+++ b/cwl-generator/templates/chipseq-02-trim.j2
@@ -48,9 +48,7 @@ inputs:
     type: string
     default: "-phred33"
   - id: "#trimmomatic_jar_path"
-    type:
-      - 'null'
-      - string
+    type: string
     default: "/usr/share/java/trimmomatic.jar"
     description: "Trimmomatic Java jar file"
   - id: "#trimmomatic_java_opts"

--- a/cwl-generator/templates/chipseq-02-trim.j2
+++ b/cwl-generator/templates/chipseq-02-trim.j2
@@ -1,0 +1,227 @@
+#!/usr/bin/env cwl-runner
+
+class: Workflow
+description: "GGR_ChIP-seq 02 trimming - reads: {{read_type|upper}}"
+
+requirements:
+  - class: ScatterFeatureRequirement
+
+inputs:
+{% if read_type == "pe" %}
+  - id: "#input_read1_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input read 1 fastq files"
+  - id: "#input_read2_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input read 2 fastq files"
+  - id: "#input_read1_adapters_files"
+    type:
+      type: array
+      items: File
+    description: "Input read 1 adapters files"
+  - id: "#input_read2_adapters_files"
+    type:
+      type: array
+      items: File
+    description: "Input read 2 adapters files"
+{% else %}
+  - id: "#input_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input fastq files"
+  - id: "#input_adapters_files"
+    type:
+      type: array
+      items: File
+    description: "Input adapters files"
+{% endif %}
+  - id: "#nthreads"
+    type: int
+    default: 1
+    description: "Number of threads"
+  - id: "#quality_score"
+    type: string
+    default: "-phred33"
+  - id: "#trimmomatic_jar_path"
+    type:
+      - 'null'
+      - string
+    default: "/usr/share/java/trimmomatic.jar"
+    description: "Trimmomatic Java jar file"
+  - id: "#trimmomatic_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list"
+
+outputs:
+{% if read_type == 'pe' %}
+  - id: "#output_data_fastq_read1_trimmed_files"
+    source: "#trimmomatic-pe.output_read1_trimmed_paired_file"
+    description: "Trimmed fastq files for paired read 1"
+    type:
+      type: array
+      items: File
+  - id: "#output_data_fastq_read2_trimmed_files"
+    source: "#trimmomatic-pe.output_read2_trimmed_paired_file"
+    description: "Trimmed fastq files for paired read 2"
+    type:
+      type: array
+      items: File
+  - id: "#output_trimmed_read1_fastq_read_count"
+    source: "#count_fastq_reads_read1.output_read_count"
+    description: "Trimmed read counts of paired read 1 fastq files"
+    type:
+      type: array
+      items: File
+  - id: "#output_trimmed_read2_fastq_read_count"
+    source: "#count_fastq_reads_read2.output_read_count"
+    description: "Trimmed read counts of paired read 2 fastq files"
+    type:
+      type: array
+      items: File
+{% else %}
+  - id: "#output_data_fastq_trimmed_files"
+    source: "#trimmomatic-se.output_trimmed_file"
+    description: "Trimmed fastq files"
+    type:
+      type: array
+      items: File
+  - id: "#trimmed_fastq_read_count"
+    source: "#count_fastq_reads.output_read_count"
+    description: "Trimmed read counts of fastq files"
+    type:
+      type: array
+      items: File
+{% endif %}
+
+steps:
+{% if read_type == 'pe' %}
+  - id: "#concat_adapters"
+    run: {import: "../utils/concat-files.cwl"}
+    scatter:
+      - "#concat_adapters.input_file1"
+      - "#concat_adapters.input_file2"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#concat_adapters.input_file1"
+        source: "#input_read1_adapters_files"
+      - id: "#concat_adapters.input_file2"
+        source: "#input_read2_adapters_files"
+    outputs:
+      - id: "#concat_adapters.output_file"
+  - id: "#trimmomatic-pe"
+    run: {import: "../trimmomatic/trimmomatic-pe.cwl"}
+    scatter:
+      - "#trimmomatic-pe.input_read1_fastq_file"
+      - "#trimmomatic-pe.input_read2_fastq_file"
+      - "#trimmomatic-pe.input_adapters_file"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#trimmomatic-pe.input_read1_fastq_file"
+        source: "#input_read1_fastq_files"
+      - id: "#trimmomatic-pe.input_read2_fastq_file"
+        source: "#input_read2_fastq_files"
+      - id: "#trimmomatic-pe.input_adapters_file"
+        source: "#concat_adapters.output_file"
+      - id: "#trimmomatic-pe.nthreads"
+        source: "#nthreads"
+      - id: "#trimmomatic-pe.java_opts"
+        source: "#trimmomatic_java_opts"
+      - id: "#trimmomatic-pe.trimmomatic_jar_path"
+        source: "#trimmomatic_jar_path"
+    outputs:
+      - id: "#trimmomatic-pe.output_read1_trimmed_paired_file"
+#      - id: "#trimmomatic-pe.output_read1_trimmed_unpaired_file"
+      - id: "#trimmomatic-pe.output_read2_trimmed_paired_file"
+#      - id: "#trimmomatic-pe.output_read2_trimmed_unpaired_file"
+  - id: "#extract_basename_read1"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename_read1.input_file"
+    inputs:
+      - id: "#extract_basename_read1.input_file"
+        source: "#trimmomatic-pe.output_read1_trimmed_paired_file"
+    outputs:
+      - id: "#extract_basename_read1.output_basename"
+  - id: "#extract_basename_read2"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename_read2.input_file"
+    inputs:
+      - id: "#extract_basename_read2.input_file"
+        source: "#trimmomatic-pe.output_read2_trimmed_paired_file"
+    outputs:
+      - id: "#extract_basename_read2.output_basename"
+  - id: "#count_fastq_reads_read1"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_fastq_reads_read1.input_fastq_file"
+      - "#count_fastq_reads_read1.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastq_reads_read1.input_fastq_file"
+        source: "#trimmomatic-pe.output_read1_trimmed_paired_file"
+      - id: "#count_fastq_reads_read1.input_basename"
+        source: "#extract_basename_read1.output_basename"
+    outputs:
+      - id: "#count_fastq_reads_read1.output_read_count"
+  - id: "#count_fastq_reads_read2"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_fastq_reads_read2.input_fastq_file"
+      - "#count_fastq_reads_read2.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastq_reads_read2.input_fastq_file"
+        source: "#trimmomatic-pe.output_read2_trimmed_paired_file"
+      - id: "#count_fastq_reads_read2.input_basename"
+        source: "#extract_basename_read2.output_basename"
+    outputs:
+      - id: "#count_fastq_reads_read2.output_read_count"
+{% else %}
+  - id: "#trimmomatic-se"
+    run: {import: "../trimmomatic/trimmomatic-se.cwl"}
+    scatter:
+      - "#trimmomatic-se.input_fastq_file"
+      - "#trimmomatic-se.input_adapters_file"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#trimmomatic-se.input_fastq_file"
+        source: "#input_fastq_files"
+      - id: "#trimmomatic-se.input_adapters_file"
+        source: "#input_adapters_files"
+      - id: "#trimmomatic-se.nthreads"
+        source: "#nthreads"
+      - id: "#trimmomatic-se.java_opts"
+        source: "#trimmomatic_java_opts"
+      - id: "#trimmomatic-se.trimmomatic_jar_path"
+        source: "#trimmomatic_jar_path"
+    outputs:
+      - id: "#trimmomatic-se.output_trimmed_file"
+  - id: "#extract_basename"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename.input_file"
+    inputs:
+      - id: "#extract_basename.input_file"
+        source: "#trimmomatic-se.output_trimmed_file"
+    outputs:
+      - id: "#extract_basename.output_basename"
+  - id: "#count_fastq_reads"
+    run: {import: "../utils/count-fastq-reads.cwl" }
+    scatter:
+      - "#count_fastq_reads.input_fastq_file"
+      - "#count_fastq_reads.input_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#count_fastq_reads.input_fastq_file"
+        source: "#trimmomatic-se.output_trimmed_file"
+      - id: "#count_fastq_reads.input_basename"
+        source: "#extract_basename.output_basename"
+    outputs:
+      - id: "#count_fastq_reads.output_read_count"
+{% endif %}
+

--- a/cwl-generator/templates/chipseq-03-map.j2
+++ b/cwl-generator/templates/chipseq-03-map.j2
@@ -1,7 +1,7 @@
 #!/usr/bin/env cwl-runner
 
 class: Workflow
-description: "GGR_ChIP-{{ read_type }}q 03 mapping - reads: {{read_type|upper}}"
+description: "GGR_ChIP-seq 03 mapping - reads: {{read_type|upper}}"
 
 requirements:
   - class: ScatterFeatureRequirement

--- a/cwl-generator/templates/chipseq-03-map.j2
+++ b/cwl-generator/templates/chipseq-03-map.j2
@@ -1,0 +1,289 @@
+#!/usr/bin/env cwl-runner
+
+class: Workflow
+description: "GGR_ChIP-{{ read_type }}q 03 mapping - reads: {{read_type|upper}}"
+
+requirements:
+  - class: ScatterFeatureRequirement
+  - class: SubworkflowFeatureRequirement
+
+inputs:
+{% if read_type == "pe" %}
+  - id: "#input_fastq_read1_files"
+    type:
+      type: array
+      items: File
+    description: "Input fastq paired-end read 1 files"
+  - id: "#input_fastq_read2_files"
+    type:
+      type: array
+      items: File
+    description: "Input fastq paired-end read 2 files"
+{% else %}
+  - id: "#input_fastq_files"
+    type:
+      type: array
+      items: File
+    description: "Input fastq files"
+{% endif %}
+  - id: "#genome_ref_first_index_file"
+    type: File
+    description: "Bowtie first index files for reference genome (e.g. *1.ebwt). The rest of the files should be in the same folder."
+  - id: "#genome_sizes_file"
+    type: File
+    description: "Genome sizes tab-delimited file (used in samtools)"
+  - id: "#ENCODE_blacklist_bedfile"
+    type: File
+    description: "Bedfile containing ENCODE consensus blacklist regions to be excluded."
+  - id: "#nthreads"
+    type: int
+    default: 1
+  - id: "#picard_jar_path"
+    type: string
+    default: "/usr/picard/picard.jar"
+    description: "Picard Java jar file"
+  - id: "#picard_java_opts"
+    type:
+      - 'null'
+      - string
+    description: "JVM arguments should be a quoted, space separated list (e.g. \"-Xms128m -Xmx512m\")"
+
+outputs:
+  - id: "#output_picard_mark_duplicates_files"
+    source: "#remove_duplicates.output_metrics_file"
+    description: "Picard MarkDuplicates metrics files."
+    type:
+      type: array
+      items: File
+  - id: "#output_data_sorted_dedup_bam_files"
+    source: "#sort_dedup_bams.sorted_file"
+    description: "BAM files without duplicate reads."
+    type:
+      type: array
+      items: File
+  - id: "#output_index_dedup_bam_files"
+    source: "#index_dedup_bams.index_file"
+    description: "Index for BAM files without duplicate reads."
+    type:
+      type: array
+      items: File
+  - id: "#output_preseq_c_curve_files"
+    source: "#preseq-c-curve.output_file"
+    description: "Preseq c_curve output files."
+    type:
+      type: array
+      items: File
+#  - id: "#output_preseq_lc_extrap_files"
+#    source: "#preseq-lc-extrap.output_file"
+#    description: "Preseq lc_extrap output files."
+#    type:
+#      type: array
+#      items: File
+  - id: "#output_pbc_files"
+    source: "#execute_pcr_bottleneck_coef.pbc_file"
+    description: "PCR Bottleneck Coeficient files."
+    type:
+      type: array
+      items: File
+  - id: "#output_bowtie_log"
+    source: "#bowtie-{{ read_type }}.output_bowtie_log"
+    description: "Bowtie log file."
+    type:
+      type: array
+      items: File
+
+steps:
+
+  - id: "#extract_basename_1"
+    run: {import: "../utils/extract-basename.cwl" }
+    scatter: "#extract_basename_1.input_file"
+    inputs:
+      - id: "#extract_basename_1.input_file"
+        source: "#input_fastq{% if read_type == "pe" %}_read1{% endif %}_files"
+    outputs:
+      - id: "#extract_basename_1.output_basename"
+  - id: "#extract_basename_2"
+    run: {import: "../utils/remove-extension.cwl" }
+    scatter: "#extract_basename_2.file_path"
+    inputs:
+      - id: "#extract_basename_2.file_path"
+        source: "#extract_basename_1.output_basename"
+    outputs:
+      - id: "#extract_basename_2.output_path"
+  - id: "#bowtie-{{ read_type }}"
+    run: {import: "../map/bowtie-{{ read_type }}.cwl"}
+    scatter:
+{% if read_type == "pe" %}
+      - "#bowtie-{{ read_type }}.input_fastq_read1_file"
+      - "#bowtie-{{ read_type }}.input_fastq_read2_file"
+{% else %}
+      - "#bowtie-{{ read_type }}.input_fastq_file"
+{% endif %}
+      - "#bowtie-{{ read_type }}.output_filename"
+    scatterMethod: dotproduct
+    inputs:
+{% if read_type == "pe" %}
+      - id: "#bowtie-{{ read_type }}.input_fastq_read1_file"
+        source: "#input_fastq_read1_files"
+      - id: "#bowtie-{{ read_type }}.input_fastq_read2_file"
+        source: "#input_fastq_read2_files"
+{% else %}
+      - id: "#bowtie-{{ read_type }}.input_fastq_file"
+        source: "#input_fastq_files"
+{% endif %}
+      - id: "#bowtie-{{ read_type }}.output_filename"
+        source: "#extract_basename_2.output_path"
+      - id: "#bowtie-{{ read_type }}.genome_ref_first_index_file"
+        source: "#genome_ref_first_index_file"
+      - id: "#bowtie-{{ read_type }}.nthreads"
+        source: "#nthreads"
+    outputs:
+      - id: "#bowtie-{{ read_type }}.output_aligned_file"
+      - id: "#bowtie-{{ read_type }}.output_bowtie_log"
+  - id: "#sam2bam"
+    run: {import: "../map/samtools2bam.cwl"}
+    scatter:
+      - "#sam2bam.input_file"
+    inputs:
+      - id: "#sam2bam.input_file"
+        source: "#bowtie-{{ read_type }}.output_aligned_file"
+    outputs:
+      - id: "#sam2bam.bam_file"
+  - id: "#sort_bams"
+    run: {import: "../map/samtools-sort.cwl"}
+    scatter:
+      - "#sort_bams.input_file"
+    inputs:
+      - id: "#sort_bams.input_file"
+        source: "#sam2bam.bam_file"
+      - id: "#sort_bams.nthreads"
+        source: "#nthreads"
+    outputs:
+      - id: "#sort_bams.sorted_file"
+  - id: "#filter-unmapped"
+    run: {import: "../map/samtools-filter-unmapped.cwl"}
+    scatter:
+      - "#filter-unmapped.input_file"
+      - "#filter-unmapped.output_filename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#filter-unmapped.input_file"
+        source: "#sort_bams.sorted_file"
+      - id: "#filter-unmapped.output_filename"
+        source: "#extract_basename_2.output_path"
+    outputs:
+      - id: "#filter-unmapped.filtered_file"
+  - id: "#filtered2sorted"
+    run: {import: "../map/samtools-sort.cwl"}
+    scatter:
+      - "#filtered2sorted.input_file"
+    inputs:
+      - id: "#filtered2sorted.input_file"
+        source: "#filter-unmapped.filtered_file"
+      - id: "#filtered2sorted.nthreads"
+        source: "#nthreads"
+    outputs:
+      - id: "#filtered2sorted.sorted_file"
+  - id: "#preseq-c-curve"
+    run: {import: "../map/preseq-c_curve.cwl"}
+    scatter:
+      - "#preseq-c-curve.input_sorted_file"
+      - "#preseq-c-curve.output_file_basename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#preseq-c-curve.input_sorted_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#preseq-c-curve.output_file_basename"
+        source: "#extract_basename_2.output_path"
+{% if read_type == 'pe' %}
+      - id: "#preseq-c-curve.pe"
+        default: true
+{% endif %}
+    outputs:
+      - id: "#preseq-c-curve.output_file"
+#  - id: "#preseq-lc-extrap"
+#    run: {import: "../map/preseq-lc_extrap.cwl"}
+#    scatter:
+#      - "#preseq-lc-extrap.input_sorted_file"
+#      - "#preseq-lc-extrap.output_file_basename"
+#    scatterMethod: dotproduct
+#    inputs:
+#      - id: "#preseq-lc-extrap.input_sorted_file"
+#        source: "#filtered2sorted.sorted_file"
+#      - id: "#preseq-lc-extrap.output_file_basename"
+#        source: "#extract_basename_2.output_path"
+#      - id: "#preseq-lc-extrap.s"
+#        default: 100000
+{% if read_type == 'pe' %}
+#      - id: "#preseq-lc-extrap.pe"
+#        default: true
+{% endif %}
+#    outputs:
+#      - id: "#preseq-lc-extrap.output_file"
+  - id: "#execute_pcr_bottleneck_coef"
+    run: {import: "../map/pcr-bottleneck-coef.cwl"}
+    inputs:
+      - id: "#execute_pcr_bottleneck_coef.input_bam_files"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#execute_pcr_bottleneck_coef.genome_sizes"
+        source: "#genome_sizes_file"
+      - id: "#execute_pcr_bottleneck_coef.input_output_filenames"
+        source: "#extract_basename_2.output_path"
+    outputs:
+      - id: "#execute_pcr_bottleneck_coef.pbc_file"
+  - id: "#remove_duplicates"
+    run: {import: "../map/picard-MarkDuplicates.cwl"}
+    scatter:
+      - "#remove_duplicates.input_file"
+      - "#remove_duplicates.output_filename"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#remove_duplicates.input_file"
+        source: "#filtered2sorted.sorted_file"
+      - id: "#remove_duplicates.output_filename"
+        source: "#extract_basename_2.output_path"
+      - id: "#remove_duplicates.java_opts"
+        source: "#picard_java_opts"
+      - id: "#remove_duplicates.picard_jar_path"
+        source: "#picard_jar_path"
+    outputs:
+      - id: "#remove_duplicates.output_metrics_file"
+      - id: "#remove_duplicates.output_dedup_bam_file"
+  - id: "#remove_encode_blacklist"
+    run: {import: "../map/bedtools-intersect.cwl"}
+    scatter:
+      - "#remove_encode_blacklist.a"
+      - "#remove_encode_blacklist.output_basename_file"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#remove_encode_blacklist.v"
+        default: true
+      - id: "#remove_encode_blacklist.output_basename_file"
+        source: "#extract_basename_2.output_path"
+      - id: "#remove_encode_blacklist.a"
+        source: "#remove_duplicates.output_dedup_bam_file"
+      - id: "#remove_encode_blacklist.b"
+        source: "#ENCODE_blacklist_bedfile"
+    outputs:
+      - id: "#remove_encode_blacklist.file_wo_blacklist_regions"
+  - id: "#sort_dedup_bams"
+    run: {import: "../map/samtools-sort.cwl"}
+    scatter:
+      - "#sort_dedup_bams.input_file"
+    inputs:
+      - id: "#sort_dedup_bams.input_file"
+        source: "#remove_encode_blacklist.file_wo_blacklist_regions"
+      - id: "#sort_dedup_bams.nthreads"
+        source: "#nthreads"
+    outputs:
+      - id: "#sort_dedup_bams.sorted_file"
+  - id: "#index_dedup_bams"
+    run: {import: "../map/samtools-index.cwl"}
+    scatter:
+      - "#index_dedup_bams.input_file"
+    inputs:
+      - id: "#index_dedup_bams.input_file"
+        source: "#sort_dedup_bams.sorted_file"
+    outputs:
+      - id: "#index_dedup_bams.index_file"
+

--- a/cwl-generator/templates/chipseq-04-peakcall.j2
+++ b/cwl-generator/templates/chipseq-04-peakcall.j2
@@ -1,0 +1,175 @@
+#!/usr/bin/env cwl-runner
+
+class: Workflow
+description: "GGR_ChIP-seq 04 quantification - region: {{ peak_type }}, samples: {{ sample_types|join(' and ') }}."
+requirements:
+  - class: ScatterFeatureRequirement
+  - class: StepInputExpressionRequirement
+
+inputs:
+  - id: "#input_bam_files"
+    type:
+      type: array
+      items: File
+  - id: "#input_bam_format"
+    type: string
+    description: "BAM or BAMPE for single-end and paired-end reads respectively (default: BAM)"
+    default: "BAM"
+{%  if "control" in sample_types %}
+  - id: "#input_control_bam_files"
+    type:
+      type: array
+      items: File
+{% endif %}
+  - id: "#nthreads"
+    type: int
+    default: 1
+
+outputs:
+  - id: "#output_spp_x_cross_corr"
+    source: "#spp.output_spp_cross_corr"
+    description: "peakshift/phantomPeak results file"
+    type:
+      type: array
+      items: File
+  - id: "#output_spp_cross_corr_plot"
+    source: "#spp.output_spp_cross_corr_plot"
+    description: "peakshift/phantomPeak results file"
+    type:
+      type: array
+      items: File
+  - id: "#output_{{ peak_type }}peak_file"
+    source: "#peak-calling-{{ peak_type }}.output_{{ peak_type }}peak_file"
+    description: "peakshift/phantomPeak results file"
+    type:
+      type: array
+      items: File
+  - id: "#output_extended_{{ peak_type }}peak_file"
+    source: "#peak-calling-{{ peak_type }}.output_ext_frag_bdg_file"
+    description: "peakshift/phantomPeak extended fragment results file"
+    type:
+      type: array
+      items: File
+  - id: "#output_peak_xls_file"
+    source: "#peak-calling-{{ peak_type }}.output_peak_xls_file"
+    description: "Peak calling report file (*_peaks.xls file produced by MACS2)"
+    type:
+      type: array
+      items: File
+  - id: "#output_filtered_read_count_file"
+    source: "#count-reads-filtered.read_count_file"
+    description: "Filtered read count reported by MACS2"
+    type:
+      type: array
+      items: File
+  - id: "#output_peak_count_within_replicate"
+    source: "#count-peaks.output_counts"
+    description: "Peak counts within replicate"
+    type:
+      type: array
+      items: File
+  - id: "#output_read_in_peak_count_within_replicate"
+    source: "#extract-count-reads-in-peaks.output_read_count"
+    description: "Peak counts within replicate"
+    type:
+      type: array
+      items: File
+steps:
+  - id: "#spp"
+    run: {import: "../spp/spp{% if 'control' in sample_types %}-with-control{% endif %}.cwl"}
+    scatter:
+      - "#spp.input_bam"
+{% if 'control' in sample_types %}
+      - "#spp.control_bam"
+{%  endif %}
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#spp.input_bam"
+        source: "#input_bam_files"
+{% if 'control' in sample_types %}
+      - id: "#spp.control_bam"
+        source: "#input_control_bam_files"
+{% endif %}
+      - id: "#spp.savp"
+        default: True
+      - id: "#spp.nthreads"
+        source: "#nthreads"
+    outputs:
+      - id: "#spp.output_spp_cross_corr"
+      - id: "#spp.output_spp_cross_corr_plot"
+  - id: "#extract-peak-frag-length"
+    run: {import: "../spp/extract-best-frag-length.cwl"}
+    scatter: "#extract-peak-frag-length.input_spp_txt_file"
+    inputs:
+      - id: "#extract-peak-frag-length.input_spp_txt_file"
+        source: "#spp.output_spp_cross_corr"
+    outputs:
+      - id: "#extract-peak-frag-length.output_best_frag_length"
+  - id: "#peak-calling-{{ peak_type }}"
+    run: {import: "../peak_calling/macs2-callpeak-{{ peak_type }}{% if 'control' in sample_types %}-with-control{% endif %}.cwl"}
+    scatter:
+      - "#peak-calling-{{ peak_type }}.treatment_sample_file"
+{% if 'control' in sample_types %}
+      - "#peak-calling-{{ peak_type }}.control_sample_file"
+{% endif %}
+      - "#peak-calling-{{ peak_type }}.extsize"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#peak-calling-{{ peak_type }}.treatment_sample_file"
+        source: "#input_bam_files"
+{% if 'control' in sample_types %}
+      - id: "#peak-calling-{{ peak_type }}.control_sample_file"
+        source: "#input_control_bam_files"
+{% endif %}
+      - id: "#peak-calling-{{ peak_type }}.extsize"
+        source: "#extract-peak-frag-length.output_best_frag_length"
+      - id: "#peak-calling-{{ peak_type }}.nomodel"
+        default: True
+      - id: "#peak-calling-{{ peak_type }}.format"
+        source: "#input_bam_format"
+    outputs:
+      - id: "#peak-calling-{{ peak_type }}.output_{{ peak_type }}peak_file"
+      - id: "#peak-calling-{{ peak_type }}.output_ext_frag_bdg_file"
+      - id: "#peak-calling-{{ peak_type }}.output_peak_xls_file"
+  - id: "#count-reads-filtered"
+    run: {import: "../peak_calling/count-reads-after-filtering.cwl"}
+    scatter: "#count-reads-filtered.peak_xls_file"
+    inputs:
+      - id: "#count-reads-filtered.peak_xls_file"
+        source: "#peak-calling-{{ peak_type }}.output_peak_xls_file"
+    outputs:
+      - id: "#count-reads-filtered.read_count_file"
+  - id: "#count-peaks"
+    run: {import: "../utils/count-with-output-suffix.cwl"}
+    scatter: "#count-peaks.input_file"
+    inputs:
+      - id: "#count-peaks.input_file"
+        source: "#peak-calling-{{ peak_type }}.output_{{ peak_type }}peak_file"
+      - id: "#count-peaks.output_suffix"
+        valueFrom: ".peak_count.within_replicate.txt"
+    outputs:
+      - id: "#count-peaks.output_counts"
+  - id: "#filter-reads-in-peaks"
+    run: {import: "../peak_calling/samtools-filter-in-bedfile.cwl"}
+    scatter:
+      - "#filter-reads-in-peaks.input_bam_file"
+      - "#filter-reads-in-peaks.input_bedfile"
+    scatterMethod: dotproduct
+    inputs:
+      - id: "#filter-reads-in-peaks.input_bam_file"
+        source: "#input_bam_files"
+      - id: "#filter-reads-in-peaks.input_bedfile"
+        source: "#peak-calling-{{ peak_type }}.output_{{ peak_type }}peak_file"
+    outputs:
+      - id: "#filter-reads-in-peaks.filtered_file"
+  - id: "#extract-count-reads-in-peaks"
+    run: {import: "../peak_calling/samtools-extract-number-mapped-reads.cwl"}
+    scatter: "#extract-count-reads-in-peaks.input_bam_file"
+    inputs:
+      - id: "#extract-count-reads-in-peaks.input_bam_file"
+        source: "#filter-reads-in-peaks.filtered_file"
+      - id: "#extract-count-reads-in-peaks.output_suffix"
+        valueFrom: ".read_count.within_replicate.txt"
+    outputs:
+      - id: "#extract-count-reads-in-peaks.output_read_count"
+

--- a/cwl-generator/yaml-files/chipseq-01-qc.yaml
+++ b/cwl-generator/yaml-files/chipseq-01-qc.yaml
@@ -1,0 +1,4 @@
+-
+  read_type: pe
+-
+  read_type: se

--- a/cwl-generator/yaml-files/chipseq-02-trim.yaml
+++ b/cwl-generator/yaml-files/chipseq-02-trim.yaml
@@ -1,0 +1,4 @@
+-
+  read_type: pe
+-
+  read_type: se

--- a/cwl-generator/yaml-files/chipseq-03-map.yaml
+++ b/cwl-generator/yaml-files/chipseq-03-map.yaml
@@ -1,0 +1,4 @@
+-
+  read_type: pe
+-
+  read_type: se

--- a/cwl-generator/yaml-files/chipseq-04-peakcall.yaml
+++ b/cwl-generator/yaml-files/chipseq-04-peakcall.yaml
@@ -1,0 +1,18 @@
+-
+  peak_type: broad
+  sample_types:
+    - treatment
+-
+  peak_type: narrow
+  sample_types:
+    - treatment
+-
+  peak_type: narrow
+  sample_types:
+    - treatment
+    - control
+-
+  peak_type: broad
+  sample_types:
+    - treatment
+    - control


### PR DESCRIPTION
Similar to what it was previously done with the top level pipelines, by having all the associated workflows in Jinja2 templates it is easier to consistently modify them and keep the workflows up to date. 