### PR TITLE
Parse metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ commands
 #scripts_local_run
 *.json
 .idea/
+json-generator/*.txt

--- a/json-generator/run.py
+++ b/json-generator/run.py
@@ -74,7 +74,12 @@ def main():
     # Parse input
     args = parser.parse_args()
 
-    if args.outdir and os.path.isdir(args.outdir) and not os.path.exists(args.outdir):
+    if os.path.isfile(args.outdir):
+        print "[ERROR] :: Target output directory is an existing file."
+        import sys
+        sys.exit(1)
+
+    if args.outdir and not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
 
     # Generate outputs

--- a/json-generator/run.py
+++ b/json-generator/run.py
@@ -1,0 +1,88 @@
+import textwrap
+import csv
+import argparse
+from collections import defaultdict
+from jinja2 import Environment, PackageLoader
+import os
+
+
+def save_or_print_json(json_str, outdir, json_name):
+    if outdir:
+        with open("%s/%s.json" % (outdir, json_name), 'w') as cout:
+            cout.writelines(json_str)
+    else:
+        print "#%s.json" % json_name
+        print json_str
+
+
+class MetadataParser(object):
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.experiment_type = os.path.splitext(os.path.basename(file_path))[0].split('_')[0].split('.')[0].split('-')[0]
+        self.records = self.load_file()
+
+    def render_json(self, wf_conf, samples_list, data_dir, template_name):
+        env = Environment(loader=PackageLoader(package_name='json-generator'))
+        template = env.get_template(template_name + '.j2')
+        json_str = template.render({'wf_conf': wf_conf, 'samples_list': samples_list, 'data_dir': data_dir})
+        json_str = '\n'.join([l for l in json_str.split('\n') if l.strip() != ''])  # Remove empty lines
+        return json_str
+
+    def parse_metadata(self, data_dir):
+        samples_dict = defaultdict(list)
+        wf_conf_dict = {}
+        for r in self.records:
+            read_type = r['Paired-end or single-end'].lower()
+            peak_type = r['Peak type'].lower()
+            sample_names = {'treatment': r['Name']}
+            wf_key = '-'.join([read_type, peak_type])
+            if 'Control' in r.keys():
+                sample_names['control'] = r['Control']
+                wf_key += '-with-control'
+            wf_conf_dict[wf_key] = {'iter': r['Iter num'], 'rt': read_type, 'pt': peak_type, 'st': sample_names.keys()}
+            samples_dict[wf_key].append(sample_names)
+        for wf_key, samples_list in samples_dict.iteritems():
+            yield self.render_json(wf_conf_dict[wf_key], sorted(samples_list), data_dir, self.experiment_type), wf_key
+
+    def load_file(self):
+        rows = []
+        with open(self.file_path, 'rb') as f:
+            reader = csv.DictReader(f, delimiter='\t')
+            for row in reader:
+                rows.append(row)
+        return rows
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description=textwrap.dedent('''
+            Parse metadata and create workflow JSONs using templates
+            --------------------------------------------------------
+            '''))
+
+    # Base script options
+    parser.add_argument('-o', '--outdir', metavar='output_dir', required=False, dest='outdir', type=str,
+                        help='Output directory where the files will be placed.')
+    parser.add_argument('-m', '--metadata-file', dest='meta_file', required=True,
+                        help='Metadata file used to create the JSON config files. By convention, the file name should '
+                             'start with the type of experiment, for example *chip-seq* or *chip_seq*. '
+                             'Internally, this name is used identify the target template.')
+    parser.add_argument('-d', '--data-dir', dest='data_dir',
+                        default='/data/reddylab/projects/GGR/data/chip_seq/processed_raw_reads',
+                        help='Project directory containing the fastq data files.')
+
+    # Parse input
+    args = parser.parse_args()
+
+    if args.outdir and os.path.isdir(args.outdir) and not os.path.exists(args.outdir):
+        os.mkdir(args.outdir)
+
+    # Generate outputs
+    meta_parser = MetadataParser(args.meta_file)
+    file_basename = os.path.splitext(os.path.basename(args.meta_file))[0]
+    for json_str, conf_name in meta_parser.parse_metadata(args.data_dir.rstrip('/')):
+        save_or_print_json(json_str, args.outdir, file_basename + '-' + conf_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/json-generator/run.py
+++ b/json-generator/run.py
@@ -36,7 +36,7 @@ class MetadataParser(object):
             peak_type = r['Peak type'].lower()
             sample_names = {'treatment': r['Name']}
             wf_key = '-'.join([read_type, peak_type])
-            if 'Control' in r.keys():
+            if 'Control' in r.keys() and r['Control'] and r['Control'].upper() != 'NA':
                 sample_names['control'] = r['Control']
                 wf_key += '-with-control'
             wf_conf_dict[wf_key] = {'iter': r['Iter num'], 'rt': read_type, 'pt': peak_type, 'st': sample_names.keys()}

--- a/json-generator/templates/chip.j2
+++ b/json-generator/templates/chip.j2
@@ -26,6 +26,7 @@
     ],
     {% endif %}
 {% endif %}
+    "default_adapters_file": { "class": "File", "path": "/data/reddylab/projects/GGR/auxiliary/adapters/default_adapters.fasta" },
     "genome_ref_first_index_file": { "class": "File", "path": "/data/reddylab/Reference_Data/Genomes/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.1.ebwt"},
     "genome_sizes_file": { "class": "File", "path": "/data/reddylab/projects/GGR/auxiliary/hg38.sizes" },
     "ENCODE_blacklist_bedfile": { "class": "File", "path": "/data/reddylab/Reference_Data/ENCODE/wgEncodeDacMapabilityConsensusExcludable.hg38.bed" },

--- a/json-generator/templates/chip.j2
+++ b/json-generator/templates/chip.j2
@@ -1,0 +1,41 @@
+{
+    "input{% if 'control' in wf_conf['st'] %}_treatment{% endif %}_fastq{% if 'pe' == wf_conf['rt'] %}_read1{% endif %}_files": [
+    {% for samples in samples_list %}
+        { "class": "File", "path": "{{ data_dir }}/{{ wf_conf['iter'] }}/{{ samples['treatment'] }}{% if 'pe' == wf_conf['rt'] %}.R1{% endif %}.fastq" }{% if loop.index < samples_list|length %},{% endif %}
+    {% endfor %}
+    ],
+{% if 'pe' == wf_conf['rt'] %}
+    "input{% if 'control' in wf_conf['st'] %}_treatment{% endif %}_fastq_read2_files": [
+    {% for samples in samples_list %}
+        { "class": "File", "path": "{{ data_dir }}/{{ wf_conf['iter'] }}/{{ samples['treatment'] }}.R2.fastq" }{% if loop.index < samples_list|length %},{% endif %}
+    {% endfor %}
+    ],
+{% endif %}
+{% if 'control' in wf_conf['st'] %}
+
+    "input_control_fastq{% if 'pe' == wf_conf['rt'] %}_read1{% endif %}_files": [
+    {% for samples in samples_list %}
+        { "class": "File", "path": "{{ data_dir }}/{{ wf_conf['iter'] }}/{{ samples['control'] }}{% if 'pe' == wf_conf['rt'] %}.R1{% endif %}.fastq" }{% if loop.index < samples_list|length %},{% endif %}
+    {% endfor %}
+    ],
+    {% if 'pe' == wf_conf['rt'] %}
+    "input_control_fastq_read2_files": [
+    {% for samples in samples_list %}
+        { "class": "File", "path": "{{ data_dir }}/{{ wf_conf['iter'] }}/{{ samples['control'] }}.R2.fastq" }{% if loop.index < samples_list|length %},{% endif %}
+    {% endfor %}
+    ],
+    {% endif %}
+{% endif %}
+
+    "genome_sizes_file": { "class": "File", "path": "/data/reddylab/projects/GGR/auxiliary/hg38.sizes" },
+    "ENCODE_blacklist_bedfile": { "class": "File", "path": "/data/reddylab/Reference_Data/ENCODE/wgEncodeDacMapabilityConsensusExcludable.hg38.bed" },
+    "nthreads_qc": 16,
+    "nthreads_trimm": 16,
+    "nthreads_map": 16,
+    "nthreads_peakcall": 16,
+    "nthreads_quant": 16,
+    "trimmomatic_jar_path": "/data/reddylab/software/Trimmomatic-0.32/trimmomatic-0.32.jar",
+    "trimmomatic_java_opts": "-Xms8000m -Xmx12000m",
+    "picard_jar_path": "/data/reddylab/software/picard/dist/picard.jar",
+    "picard_java_opts": "-Xms8000m -Xmx12000m"
+}

--- a/json-generator/templates/chip.j2
+++ b/json-generator/templates/chip.j2
@@ -26,7 +26,7 @@
     ],
     {% endif %}
 {% endif %}
-
+    "genome_ref_first_index_file": { "class": "File", "path": "/data/reddylab/Reference_Data/Genomes/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.1.ebwt"},
     "genome_sizes_file": { "class": "File", "path": "/data/reddylab/projects/GGR/auxiliary/hg38.sizes" },
     "ENCODE_blacklist_bedfile": { "class": "File", "path": "/data/reddylab/Reference_Data/ENCODE/wgEncodeDacMapabilityConsensusExcludable.hg38.bed" },
     "nthreads_qc": 16,


### PR DESCRIPTION
New python utility to generate the input JSONs for the ChIP-seq pipeline from a metadata spreadsheet. To use the utility, the path to this project should be added either to the $PYTHONPATH (preferred) or the $PATH environment variables so that Jinja2 can find the templates. 