### PR TITLE
Slurm fixes

### DIFF
--- a/GGR_ChIP-seq_pipeline/05-quantification.cwl
+++ b/GGR_ChIP-seq_pipeline/05-quantification.cwl
@@ -76,13 +76,13 @@ steps:
       - id: "#bedsort_genomecov.bed_file"
         source: "#bedtools_genomecov.output_bedfile"
     outputs:
-      - id: "#bedsort_genomecov.output_bedfile_sorted"
+      - id: "#bedsort_genomecov.bed_file_sorted"
   - id: "#bdg2bw-raw"
     run: {import: "../quant/bedGraphToBigWig.cwl"}
     scatter: "#bdg2bw-raw.bed_graph"
     inputs:
       - id: "#bdg2bw-raw.bed_graph"
-        source: "#bedsort_genomecov.output_bedfile_sorted"
+        source: "#bedsort_genomecov.bed_file_sorted"
       - id: "#bdg2bw-raw.genome_sizes"
         source: "#input_genome_sizes"
       - id: "bdg2bw-raw.output_suffix"
@@ -130,13 +130,13 @@ steps:
       - id: "#bedsort_clipped_bedfile.bed_file"
         source: "#clip-off-chrom.bed_file_clipped"
     outputs:
-      - id: "#bedsort_clipped_bedfile.output_bedfile_sorted"
+      - id: "#bedsort_clipped_bedfile.bed_file_sorted"
   - id: "#bdg2bw-extend"
     run: {import: "../quant/bedGraphToBigWig.cwl"}
     scatter: "#bdg2bw-extend.bed_graph"
     inputs:
       - id: "#bdg2bw-extend.bed_graph"
-        source: "#bedsort_clipped_bedfile.output_bedfile_sorted"
+        source: "#bedsort_clipped_bedfile.bed_file_sorted"
       - id: "#bdg2bw-extend.genome_sizes"
         source: "#input_genome_sizes"
       - id: "bdg2bw-extend.output_suffix"
@@ -163,13 +163,13 @@ steps:
       - id: "#bedsort_scaled_bdg.bed_file"
         source: "#scale-bedgraph.bedgraph_scaled"
     outputs:
-      - id: "#bedsort_scaled_bdg.output_bedfile_sorted"
+      - id: "#bedsort_scaled_bdg.bed_file_sorted"
   - id: "#bdg2bw-extend-norm"
     run: {import: "../quant/bedGraphToBigWig.cwl"}
     scatter: "#bdg2bw-extend-norm.bed_graph"
     inputs:
       - id: "#bdg2bw-extend-norm.bed_graph"
-        source: "#bedsort_scaled_bdg.output_bedfile_sorted"
+        source: "#bedsort_scaled_bdg.bed_file_sorted"
       - id: "#bdg2bw-extend-norm.genome_sizes"
         source: "#input_genome_sizes"
       - id: "bdg2bw-extend-norm.output_suffix"

--- a/GGR_ChIP-seq_pipeline/05-quantification.cwl
+++ b/GGR_ChIP-seq_pipeline/05-quantification.cwl
@@ -123,12 +123,20 @@ steps:
         source: "#input_genome_sizes"
     outputs:
       - id: "#clip-off-chrom.bed_file_clipped"
+  - id: "#bedsort_clipped_bedfile"
+    run: {import: "../quant/bedSort.cwl"}
+    scatter: "#bedsort_clipped_bedfile.bed_file"
+    inputs:
+      - id: "#bedsort_clipped_bedfile.bed_file"
+        source: "#clip-off-chrom.bed_file_clipped"
+    outputs:
+      - id: "#bedsort_clipped_bedfile.output_bedfile_sorted"
   - id: "#bdg2bw-extend"
     run: {import: "../quant/bedGraphToBigWig.cwl"}
     scatter: "#bdg2bw-extend.bed_graph"
     inputs:
       - id: "#bdg2bw-extend.bed_graph"
-        source: "#clip-off-chrom.bed_file_clipped"
+        source: "#bedsort_clipped_bedfile.output_bedfile_sorted"
       - id: "#bdg2bw-extend.genome_sizes"
         source: "#input_genome_sizes"
       - id: "bdg2bw-extend.output_suffix"
@@ -148,16 +156,23 @@ steps:
         source: "#input_read_count_dedup_files"
     outputs:
       - id: "#scale-bedgraph.bedgraph_scaled"
+  - id: "#bedsort_scaled_bdg"
+    run: {import: "../quant/bedSort.cwl"}
+    scatter: "#bedsort_scaled_bdg.bed_file"
+    inputs:
+      - id: "#bedsort_scaled_bdg.bed_file"
+        source: "#scale-bedgraph.bedgraph_scaled"
+    outputs:
+      - id: "#bedsort_scaled_bdg.output_bedfile_sorted"
   - id: "#bdg2bw-extend-norm"
     run: {import: "../quant/bedGraphToBigWig.cwl"}
     scatter: "#bdg2bw-extend-norm.bed_graph"
     inputs:
       - id: "#bdg2bw-extend-norm.bed_graph"
-        source: "#scale-bedgraph.bedgraph_scaled"
+        source: "#bedsort_scaled_bdg.output_bedfile_sorted"
       - id: "#bdg2bw-extend-norm.genome_sizes"
         source: "#input_genome_sizes"
       - id: "bdg2bw-extend-norm.output_suffix"
         default: ".fragment_extended_norm.bw"
     outputs:
       - id: "#bdg2bw-extend-norm.output_bigwig"
-

--- a/GGR_ChIP-seq_pipeline/05-quantification.cwl
+++ b/GGR_ChIP-seq_pipeline/05-quantification.cwl
@@ -32,7 +32,7 @@ inputs:
 
 outputs:
   - id: "#bigwig_raw_files"
-    source: "#bedgraph2bigwig-raw.output_bigwig"
+    source: "#bdg2bw-raw.output_bigwig"
     description: "Raw reads bigWig (signal) files"
     type:
       type: array
@@ -69,18 +69,26 @@ steps:
         default: true
     outputs:
       - id: "#bedtools_genomecov.output_bedfile"
-  - id: "#bedgraph2bigwig-raw"
-    run: {import: "../quant/bedGraphToBigWig.cwl"}
-    scatter: "#bedgraph2bigwig-raw.bed_graph"
+  - id: "#bedsort_genomecov"
+    run: {import: "../quant/bedSort.cwl"}
+    scatter: "#bedsort_genomecov.bed_file"
     inputs:
-      - id: "#bedgraph2bigwig-raw.bed_graph"
+      - id: "#bedsort_genomecov.bed_file"
         source: "#bedtools_genomecov.output_bedfile"
-      - id: "#bedgraph2bigwig-raw.genome_sizes"
+    outputs:
+      - id: "#bedsort_genomecov.output_bedfile_sorted"
+  - id: "#bdg2bw-raw"
+    run: {import: "../quant/bedGraphToBigWig.cwl"}
+    scatter: "#bdg2bw-raw.bed_graph"
+    inputs:
+      - id: "#bdg2bw-raw.bed_graph"
+        source: "#bedsort_genomecov.output_bedfile_sorted"
+      - id: "#bdg2bw-raw.genome_sizes"
         source: "#input_genome_sizes"
-      - id: "bedgraph2bigwig-raw.output_suffix"
+      - id: "bdg2bw-raw.output_suffix"
         valueFrom: ".raw.bw"
     outputs:
-      - id: "#bedgraph2bigwig-raw.output_bigwig"
+      - id: "#bdg2bw-raw.output_bigwig"
   - id: "#bamcoverage"
     run: {import: "../quant/deeptools-bamcoverage.cwl"}
     scatter: "#bamcoverage.bam"

--- a/map/picard-MarkDuplicates.cwl
+++ b/map/picard-MarkDuplicates.cwl
@@ -72,3 +72,6 @@ arguments:
   - valueFrom: $('METRICS_FILE='+inputs.output_filename + '.' + inputs.metrics_suffix)
     position: 5
     shellQuote: false
+  - valueFrom: $('TMP_DIR='+runtime.tmpdir)
+    position: 5
+    shellQuote: false

--- a/quant/bedSort.cwl
+++ b/quant/bedSort.cwl
@@ -1,0 +1,34 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: 'cwl:draft-3.dev3'
+class: CommandLineTool
+hints:
+  - class: DockerRequirement
+    dockerImageId: 'dleehr/docker-hubutils'
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs:
+  - id: "#bed_file"
+    type: File
+    description: "Bed or bedGraph file to be sorted"
+    inputBinding:
+      position: 1
+
+outputs:
+  - id: '#bed_file_sorted'
+    type: File
+    outputBinding:
+      glob: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, "") + ".sorted")
+
+baseCommand: bedSort
+arguments:
+  - valueFrom: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, "") + ".sorted")
+    position: 2
+
+description: |
+  bedSort - Sort a .bed file by chrom,chromStart
+  usage:
+     bedSort in.bed out.bed
+  in.bed and out.bed may be the same.

--- a/quant/bedSort.cwl
+++ b/quant/bedSort.cwl
@@ -20,11 +20,11 @@ outputs:
   - id: '#bed_file_sorted'
     type: File
     outputBinding:
-      glob: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, "") + ".sorted")
+      glob: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '') + ".sorted")
 
 baseCommand: bedSort
 arguments:
-  - valueFrom: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, "") + ".sorted")
+  - valueFrom: $(inputs.bed_file.path.replace(/^.*[\\\/]/, '') + ".sorted")
     position: 2
 
 description: |

--- a/trimmomatic/trimmomatic-pe.cwl
+++ b/trimmomatic/trimmomatic-pe.cwl
@@ -82,3 +82,6 @@ arguments:
   - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
     position: 12
     shellQuote: false
+  - valueFrom: $("-Djava.io.tmpdir="+runtime.tmpdir)
+    shellQuote: false
+    poition: 1

--- a/trimmomatic/trimmomatic-se.cwl
+++ b/trimmomatic/trimmomatic-se.cwl
@@ -61,3 +61,6 @@ arguments:
   - valueFrom: $("LEADING:3 TRAILING:3 SLIDINGWINDOW:4:20 MINLEN:10")
     position: 8
     shellQuote: false
+  - valueFrom: $("-Djava.io.tmpdir="+runtime.tmpdir)
+    shellQuote: false
+    poition: 1


### PR DESCRIPTION
Several fixes and improvements (some of them more crucial than others, like the usage of tmpdirs in java tools). Also, in the more recent version of the bedGraphToBigWig UCSC utility, the bed files need to be sorted. Support for bedSort has been added 