### PR TITLE
Optimizations

### DIFF
--- a/GGR_ChIP-seq_pipeline/03-map-pe.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-pe.cwl
@@ -124,6 +124,8 @@ steps:
     inputs:
       - id: "#sam2bam.input_file"
         source: "#bowtie-pe.output_aligned_file"
+      - id: "#sam2bam.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sam2bam.bam_file"
   - id: "#sort_bams"

--- a/GGR_ChIP-seq_pipeline/03-map-se.cwl
+++ b/GGR_ChIP-seq_pipeline/03-map-se.cwl
@@ -116,6 +116,8 @@ steps:
     inputs:
       - id: "#sam2bam.input_file"
         source: "#bowtie-se.output_aligned_file"
+      - id: "#sam2bam.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sam2bam.bam_file"
   - id: "#sort_bams"

--- a/cwl-generator/templates/chipseq-03-map.j2
+++ b/cwl-generator/templates/chipseq-03-map.j2
@@ -147,6 +147,8 @@ steps:
     inputs:
       - id: "#sam2bam.input_file"
         source: "#bowtie-{{ read_type }}.output_aligned_file"
+      - id: "#sam2bam.nthreads"
+        source: "#nthreads"
     outputs:
       - id: "#sam2bam.bam_file"
   - id: "#sort_bams"

--- a/map/bedtools-genomecov.cwl
+++ b/map/bedtools-genomecov.cwl
@@ -148,8 +148,8 @@ outputs:
   - id: '#output_bedfile'
     type: File
     outputBinding:
-      glob: $(inputs.ibam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.bdg')
-stdout: $(inputs.ibam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.bdg')
+      glob: $(inputs.ibam.path.replace(/^.*[\\\/]/, '') + '.bdg')
+stdout: $(inputs.ibam.path.replace(/^.*[\\\/]/, '') + '.bdg')
 baseCommand:
   - bedtools
   - genomecov

--- a/map/bedtools-genomecov.cwl
+++ b/map/bedtools-genomecov.cwl
@@ -148,8 +148,8 @@ outputs:
   - id: '#output_bedfile'
     type: File
     outputBinding:
-      glob: $(inputs.ibam.path.replace(/^.*[\\\/]/, '') + '.bdg')
-stdout: $(inputs.ibam.path.replace(/^.*[\\\/]/, '') + '.bdg')
+      glob: $(inputs.ibam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.bdg')
+stdout: $(inputs.ibam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.bdg')
 baseCommand:
   - bedtools
   - genomecov

--- a/map/bowtie-pe.cwl
+++ b/map/bowtie-pe.cwl
@@ -48,7 +48,6 @@ inputs:
       prefix: "--best"
   - id: "#chunkmbs"
     type: int
-    default: 256
     description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
     inputBinding:
       position: 5

--- a/map/bowtie-pe.cwl
+++ b/map/bowtie-pe.cwl
@@ -46,6 +46,13 @@ inputs:
     inputBinding:
       position: 5
       prefix: "--best"
+  - id: "#chunkmbs"
+    type: int
+    default: 256
+    description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
+    inputBinding:
+      position: 5
+      prefix: "--chunkmbs"
   - id: "#strata"
     type: boolean
     default: true

--- a/map/bowtie-pe.cwl
+++ b/map/bowtie-pe.cwl
@@ -29,7 +29,7 @@ inputs:
     type: int
     default: 2
     description: "Report end-to-end hits w/ <=v mismatches; ignore qualities"
-    inputBindng:
+    inputBinding:
       position: 3
       prefix: "-v"
   - id: "#X"

--- a/map/bowtie-pe.cwl
+++ b/map/bowtie-pe.cwl
@@ -47,7 +47,9 @@ inputs:
       position: 5
       prefix: "--best"
   - id: "#chunkmbs"
-    type: int
+    type:
+      - 'null'
+      - int
     description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
     inputBinding:
       position: 5

--- a/map/bowtie-se.cwl
+++ b/map/bowtie-se.cwl
@@ -48,7 +48,6 @@ inputs:
       prefix: "--best"
   - id: "#chunkmbs"
     type: int
-    default: 256
     description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
     inputBinding:
       position: 5

--- a/map/bowtie-se.cwl
+++ b/map/bowtie-se.cwl
@@ -46,6 +46,13 @@ inputs:
     inputBinding:
       position: 5
       prefix: "--best"
+  - id: "#chunkmbs"
+    type: int
+    default: 256
+    description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
+    inputBinding:
+      position: 5
+      prefix: "--chunkmbs"
   - id: "#strata"
     type: boolean
     default: true

--- a/map/bowtie-se.cwl
+++ b/map/bowtie-se.cwl
@@ -29,7 +29,7 @@ inputs:
     type: int
     default: 2
     description: "Report end-to-end hits w/ <=v mismatches; ignore qualities"
-    inputBindng:
+    inputBinding:
       position: 3
       prefix: "-v"
   - id: "#X"

--- a/map/bowtie-se.cwl
+++ b/map/bowtie-se.cwl
@@ -47,7 +47,9 @@ inputs:
       position: 5
       prefix: "--best"
   - id: "#chunkmbs"
-    type: int
+    type:
+      - 'null'
+      - int
     description: "The number of megabytes of memory a given thread is given to store path descriptors in --best mode. (Default: 256)"
     inputBinding:
       position: 5

--- a/map/samtools-sort.cwl
+++ b/map/samtools-sort.cwl
@@ -28,7 +28,7 @@ outputs:
     type: File
     description: "Sorted aligned file"
     outputBinding:
-      glob: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sorted.bam')
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sorted.bam')
 
 baseCommand: ["samtools", "sort"]
-stdout: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sorted.bam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sorted.bam')

--- a/map/samtools-sort.cwl
+++ b/map/samtools-sort.cwl
@@ -28,7 +28,7 @@ outputs:
     type: File
     description: "Sorted aligned file"
     outputBinding:
-      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sorted.bam')
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.sorted.bam')
 
 baseCommand: ["samtools", "sort"]
-stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sorted.bam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.sorted.bam')

--- a/map/samtools-view-sam.cwl
+++ b/map/samtools-view-sam.cwl
@@ -29,13 +29,20 @@ inputs:
     inputBinding:
       position: 1
       prefix: "-h"
+  - id: "#nthreads"
+    type: int
+    default: 1
+    description: "Number of threads used"
+    inputBinding:
+      position: 1
+      prefix: "-@"
 
 outputs:
   - id: "#sam_file"
     type: File
     description: "Aligned file in BAM format"
     outputBinding:
-      glob: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sam')
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sam')
 
 baseCommand: ["samtools", "view"]
-stdout: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.sam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sam')

--- a/map/samtools-view-sam.cwl
+++ b/map/samtools-view-sam.cwl
@@ -42,7 +42,7 @@ outputs:
     type: File
     description: "Aligned file in BAM format"
     outputBinding:
-      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sam')
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.sam')
 
 baseCommand: ["samtools", "view"]
-stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.sam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.sam')

--- a/map/samtools2bam.cwl
+++ b/map/samtools2bam.cwl
@@ -29,14 +29,20 @@ inputs:
     inputBinding:
       position: 1
       prefix: "-S"
+  - id: "#nthreads"
+    type: int
+    default: 1
+    description: "Number of threads used"
+    inputBinding:
+      position: 1
+      prefix: "-@"
 
 outputs:
   - id: "#bam_file"
     type: File
     description: "Aligned file in BAM format"
     outputBinding:
-      glob: "*.bam"
-      outputEval: $(self[0])
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.bam')
 
 baseCommand: ["samtools", "view", "-b"]
-stdout: $(inputs.input_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.bam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.bam')

--- a/map/samtools2bam.cwl
+++ b/map/samtools2bam.cwl
@@ -42,7 +42,7 @@ outputs:
     type: File
     description: "Aligned file in BAM format"
     outputBinding:
-      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.bam')
+      glob: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.bam')
 
 baseCommand: ["samtools", "view", "-b"]
-stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '') + '.bam')
+stdout: $(inputs.input_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.bam')

--- a/peak_calling/macs2-callpeak-broad-with-control.cwl
+++ b/peak_calling/macs2-callpeak-broad-with-control.cwl
@@ -110,25 +110,25 @@ outputs:
     type: File
     description: "Peak calling output file in broadPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.broadPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.broadPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak", "--broad"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
     position: 2

--- a/peak_calling/macs2-callpeak-broad-with-control.cwl
+++ b/peak_calling/macs2-callpeak-broad-with-control.cwl
@@ -110,25 +110,25 @@ outputs:
     type: File
     description: "Peak calling output file in broadPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.broadPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.broadPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak", "--broad"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.'))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
     position: 2

--- a/peak_calling/macs2-callpeak-broad.cwl
+++ b/peak_calling/macs2-callpeak-broad.cwl
@@ -104,25 +104,25 @@ outputs:
     type: File
     description: "Peak calling output file in broadPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.broadPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.broadPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak", "--broad"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
     position: 2

--- a/peak_calling/macs2-callpeak-broad.cwl
+++ b/peak_calling/macs2-callpeak-broad.cwl
@@ -104,25 +104,25 @@ outputs:
     type: File
     description: "Peak calling output file in broadPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.broadPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.broadPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak", "--broad"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.'))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
     position: 2

--- a/peak_calling/macs2-callpeak-narrow-with-control.cwl
+++ b/peak_calling/macs2-callpeak-narrow-with-control.cwl
@@ -109,26 +109,26 @@ outputs:
     type: File
     description: "Peak calling output file in narrowPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.narrowPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.narrowPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.'))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
     position: 2
 

--- a/peak_calling/macs2-callpeak-narrow-with-control.cwl
+++ b/peak_calling/macs2-callpeak-narrow-with-control.cwl
@@ -109,26 +109,26 @@ outputs:
     type: File
     description: "Peak calling output file in narrowPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.narrowPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.narrowPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
     position: 2
 

--- a/peak_calling/macs2-callpeak-narrow.cwl
+++ b/peak_calling/macs2-callpeak-narrow.cwl
@@ -103,25 +103,25 @@ outputs:
     type: File
     description: "Peak calling output file in narrowPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.narrowPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.narrowPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
     position: 2

--- a/peak_calling/macs2-callpeak-narrow.cwl
+++ b/peak_calling/macs2-callpeak-narrow.cwl
@@ -103,25 +103,25 @@ outputs:
     type: File
     description: "Peak calling output file in narrowPeak format."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.narrowPeak')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.narrowPeak')
   - id: "#output_ext_frag_bdg_file"
     type: File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_treat_pileup.bdg')
   - id: "#output_peak_xls_file"
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_peaks.xls')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_peaks.xls')
   - id: "#output_peak_summits_file"
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '_summits.bed')
+      glob: $(inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, '') + '_summits.bed')
 
 baseCommand: ["macs2" , "callpeak"]
 
 arguments:
-  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.'))
+  - valueFrom: $('-n=' + inputs.treatment_sample_file.path.replace(/^.*[\\\/]/, ''))
     position: 2

--- a/quant/deeptools-bamcoverage.cwl
+++ b/quant/deeptools-bamcoverage.cwl
@@ -65,11 +65,11 @@ outputs:
   - id: '#output_bam_coverage'
     type: File
     outputBinding:
-      glob: $(inputs.bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + inputs.output_suffix)
+      glob: $(inputs.bam.path.replace(/^.*[\\\/]/, '') + inputs.output_suffix)
 
 baseCommand: bamCoverage
 arguments:
-  - valueFrom: $('--outFileName=' + inputs.bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + inputs.output_suffix)
+  - valueFrom: $('--outFileName=' + inputs.bam.path.replace(/^.*[\\\/]/, '') + inputs.output_suffix)
     position: 3
 
 description: "Tool:   bedGraphToBigWig v 4 - Convert a bedGraph file to bigWig format."

--- a/quant/deeptools-bamcoverage.cwl
+++ b/quant/deeptools-bamcoverage.cwl
@@ -65,11 +65,11 @@ outputs:
   - id: '#output_bam_coverage'
     type: File
     outputBinding:
-      glob: $(inputs.bam.path.replace(/^.*[\\\/]/, '') + inputs.output_suffix)
+      glob: $(inputs.bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + inputs.output_suffix)
 
 baseCommand: bamCoverage
 arguments:
-  - valueFrom: $('--outFileName=' + inputs.bam.path.replace(/^.*[\\\/]/, '') + inputs.output_suffix)
+  - valueFrom: $('--outFileName=' + inputs.bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + inputs.output_suffix)
     position: 3
 
 description: "Tool:   bedGraphToBigWig v 4 - Convert a bedGraph file to bigWig format."

--- a/spp/spp-with-control.cwl
+++ b/spp/spp-with-control.cwl
@@ -18,7 +18,7 @@ inputs:
     description: "\t save cross-correlation plot\n"
     inputBinding:
       position: 2
-      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
+      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.pdf')
   - id: "#input_bam"
     type: File
     description: "<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped)(FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
@@ -52,14 +52,14 @@ outputs:
     type: File
     description: "peakshift/phantomPeak results file"
     outputBinding:
-      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.txt')
   - id: "#output_spp_cross_corr_plot"
     type: File
     description: "peakshift/phantomPeak results file plot"
     outputBinding:
-      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.pdf')
 
 baseCommand: run_spp.R
 arguments:
-  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
+  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.txt')
     position: 2

--- a/spp/spp-with-control.cwl
+++ b/spp/spp-with-control.cwl
@@ -18,7 +18,7 @@ inputs:
     description: "\t save cross-correlation plot\n"
     inputBinding:
       position: 2
-      valueFrom: $('-savp=' + inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.pdf')
+      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
   - id: "#input_bam"
     type: File
     description: "<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped)(FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
@@ -52,14 +52,14 @@ outputs:
     type: File
     description: "peakshift/phantomPeak results file"
     outputBinding:
-      glob: $(inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.txt')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
   - id: "#output_spp_cross_corr_plot"
     type: File
     description: "peakshift/phantomPeak results file plot"
     outputBinding:
-      glob: $(inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.pdf')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
 
 baseCommand: run_spp.R
 arguments:
-  - valueFrom: $('-out=' + inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.txt')
+  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
     position: 2

--- a/spp/spp.cwl
+++ b/spp/spp.cwl
@@ -18,7 +18,7 @@ inputs:
     description: "\t save cross-correlation plot\n"
     inputBinding:
       position: 2
-      valueFrom: $('-savp=' + inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.pdf')
+      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
   - id: "#input_bam"
     type: File
     description: "<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped)(FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
@@ -46,14 +46,14 @@ outputs:
     type: File
     description: "peakshift/phantomPeak results file"
     outputBinding:
-      glob: $(inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.txt')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
   - id: "#output_spp_cross_corr_plot"
     type: File
     description: "peakshift/phantomPeak results file plot"
     outputBinding:
-      glob: $(inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.pdf')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
 
 baseCommand: run_spp.R
 arguments:
-  - valueFrom: $('-out=' + inputs.input_bam.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.spp_cross_corr.txt')
+  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
     position: 2

--- a/spp/spp.cwl
+++ b/spp/spp.cwl
@@ -18,7 +18,7 @@ inputs:
     description: "\t save cross-correlation plot\n"
     inputBinding:
       position: 2
-      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
+      valueFrom: $('-savp=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.pdf')
   - id: "#input_bam"
     type: File
     description: "<ChIP_alignFile>, full path and name (or URL) of tagAlign/BAM file (can be gzipped)(FILE EXTENSION MUST BE tagAlign.gz, tagAlign, bam or bam.gz)"
@@ -46,14 +46,14 @@ outputs:
     type: File
     description: "peakshift/phantomPeak results file"
     outputBinding:
-      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.txt')
   - id: "#output_spp_cross_corr_plot"
     type: File
     description: "peakshift/phantomPeak results file plot"
     outputBinding:
-      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.pdf')
+      glob: $(inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.pdf')
 
 baseCommand: run_spp.R
 arguments:
-  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '') + '.spp_cross_corr.txt')
+  - valueFrom: $('-out=' + inputs.input_bam.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.spp_cross_corr.txt')
     position: 2

--- a/trimmomatic/trimmomatic-pe.cwl
+++ b/trimmomatic/trimmomatic-pe.cwl
@@ -50,31 +50,31 @@ outputs:
   - id: "#output_read1_trimmed_paired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
+      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
   - id: "#output_read1_trimmed_unpaired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
+      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
   - id: "#output_read2_trimmed_paired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
+      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
   - id: "#output_read2_trimmed_unpaired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
+      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
 
 baseCommand: java
 arguments:
   - valueFrom: "PE"
     position: 3
-  - valueFrom: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
     position: 7
-  - valueFrom: $(inputs.input_read1_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
     position: 8
-  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.paired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
     position: 9
-  - valueFrom: $(inputs.input_read2_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.unpaired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
     position: 10
   - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
     position: 11

--- a/trimmomatic/trimmomatic-pe.cwl
+++ b/trimmomatic/trimmomatic-pe.cwl
@@ -50,31 +50,31 @@ outputs:
   - id: "#output_read1_trimmed_paired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
+      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.paired.trimmed.fastq')
   - id: "#output_read1_trimmed_unpaired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
+      glob: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.unpaired.trimmed.fastq')
   - id: "#output_read2_trimmed_paired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
+      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.paired.trimmed.fastq')
   - id: "#output_read2_trimmed_unpaired_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
+      glob: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.unpaired.trimmed.fastq')
 
 baseCommand: java
 arguments:
   - valueFrom: "PE"
     position: 3
-  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.paired.trimmed.fastq')
     position: 7
-  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read1_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.unpaired.trimmed.fastq')
     position: 8
-  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.paired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.paired.trimmed.fastq')
     position: 9
-  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '') + '.unpaired.trimmed.fastq')
+  - valueFrom: $(inputs.input_read2_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.unpaired.trimmed.fastq')
     position: 10
   - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
     position: 11

--- a/trimmomatic/trimmomatic-se.cwl
+++ b/trimmomatic/trimmomatic-se.cwl
@@ -47,13 +47,13 @@ outputs:
   - id: "#output_trimmed_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.trimmed.fastq')
+      glob: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '') + '.trimmed.fastq')
 
 baseCommand: java
 arguments:
   - valueFrom: "SE"
     position: 3
-  - valueFrom: $(inputs.input_fastq_file.path.split('/').slice(-1)[0].split('\.').slice(0,-1).join('.') + '.trimmed.fastq')
+  - valueFrom: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '') + '.trimmed.fastq')
     position: 6
   - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
     position: 7

--- a/trimmomatic/trimmomatic-se.cwl
+++ b/trimmomatic/trimmomatic-se.cwl
@@ -47,13 +47,13 @@ outputs:
   - id: "#output_trimmed_file"
     type: File
     outputBinding:
-      glob: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '') + '.trimmed.fastq')
+      glob: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.trimmed.fastq')
 
 baseCommand: java
 arguments:
   - valueFrom: "SE"
     position: 3
-  - valueFrom: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '') + '.trimmed.fastq')
+  - valueFrom: $(inputs.input_fastq_file.path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '.trimmed.fastq')
     position: 6
   - valueFrom: $("ILLUMINACLIP:" + inputs.input_adapters_file.path + ":2:30:15")
     position: 7


### PR DESCRIPTION
- Added nthreads to samtools-view based tools.
- Corrections derived from executing the ChIP-seq pipeline in the cluster on a real dataset. There was an issue with a bowtie param (-v) containing a typo that prevented it from being used. The typo was inputBindng instead of inputBind**i**ng (for the record, cwltool did not complain as the inputBinding is an optional attribute).
- Changed JS code for extension replacement in favor of a more compact regex expression. 
