### PR TITLE
refactor pipelines and subworkflows after changing macs2-callpeak tool

### DIFF
--- a/ChIP-seq_pipeline/04-peakcall-broad-with-control.cwl
+++ b/ChIP-seq_pipeline/04-peakcall-broad-with-control.cwl
@@ -39,7 +39,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_extended_peak_file"
+  - id: "#output_extended_broadpeak_file"
     source: "#peak-calling.output_ext_frag_bdg_file"
     description: "peakshift/phantomPeak extended fragment results file"
     type:
@@ -100,13 +100,15 @@ steps:
   - id: "#peak-calling"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
-      - "#peak-calling.c"
+      - "#peak-calling.treatment"
+      - "#peak-calling.control"
       - "#peak-calling.extsize"
     scatterMethod: dotproduct
     inputs:
-      - id: "#peak-calling.t"
+      - id: "#peak-calling.treatment"
         source: "#input_bam_files"
-      - id: "#peak-calling.c"
+        valueFrom: $([self])
+      - id: "#peak-calling.control"
         source: "#input_control_bam_files"
       - id: "#peak-calling.broad"
         valueFrom: $(true)

--- a/ChIP-seq_pipeline/04-peakcall-broad.cwl
+++ b/ChIP-seq_pipeline/04-peakcall-broad.cwl
@@ -35,7 +35,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_extended_peak_file"
+  - id: "#output_extended_broadpeak_file"
     source: "#peak-calling.output_ext_frag_bdg_file"
     description: "peakshift/phantomPeak extended fragment results file"
     type:
@@ -92,11 +92,13 @@ steps:
   - id: "#peak-calling"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
+      - "#peak-calling.treatment"
       - "#peak-calling.extsize"
     scatterMethod: dotproduct
     inputs:
-      - id: "#peak-calling.t"
+      - id: "#peak-calling.treatment"
         source: "#input_bam_files"
+        valueFrom: $([self])
       - id: "#peak-calling.broad"
         valueFrom: $(true)
       - id: "#peak-calling.q"

--- a/ChIP-seq_pipeline/04-peakcall-narrow-with-control.cwl
+++ b/ChIP-seq_pipeline/04-peakcall-narrow-with-control.cwl
@@ -39,7 +39,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_extended_peak_file"
+  - id: "#output_extended_narrowpeak_file"
     source: "#peak-calling.output_ext_frag_bdg_file"
     description: "peakshift/phantomPeak extended fragment results file"
     type:
@@ -100,13 +100,15 @@ steps:
   - id: "#peak-calling"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
-      - "#peak-calling.c"
+      - "#peak-calling.treatment"
+      - "#peak-calling.control"
       - "#peak-calling.extsize"
     scatterMethod: dotproduct
     inputs:
-      - id: "#peak-calling.t"
+      - id: "#peak-calling.treatment"
         source: "#input_bam_files"
-      - id: "#peak-calling.c"
+        valueFrom: $([self])
+      - id: "#peak-calling.control"
         source: "#input_control_bam_files"
       - id: "#peak-calling.extsize"
         source: "#extract-peak-frag-length.output_best_frag_length"

--- a/ChIP-seq_pipeline/04-peakcall-narrow.cwl
+++ b/ChIP-seq_pipeline/04-peakcall-narrow.cwl
@@ -35,7 +35,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_extended_peak_file"
+  - id: "#output_extended_narrowpeak_file"
     source: "#peak-calling.output_ext_frag_bdg_file"
     description: "peakshift/phantomPeak extended fragment results file"
     type:
@@ -92,11 +92,13 @@ steps:
   - id: "#peak-calling"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
+      - "#peak-calling.treatment"
       - "#peak-calling.extsize"
     scatterMethod: dotproduct
     inputs:
-      - id: "#peak-calling.t"
+      - id: "#peak-calling.treatment"
         source: "#input_bam_files"
+        valueFrom: $([self])
       - id: "#peak-calling.extsize"
         source: "#extract-peak-frag-length.output_best_frag_length"
       - id: "#peak-calling.nomodel"

--- a/ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
+++ b/ChIP-seq_pipeline/pipeline-pe-narrow-with-control.cwl
@@ -277,7 +277,7 @@ outputs:
       type: array
       items: File
   - id: "#peak_call_narrowpeak_file"
-    source: "#peak_call.output_peak_file"
+    source: "#peak_call.output_narrowpeak_file"
     description: "Peaks in narrowPeak file format"
     type:
       type: array
@@ -425,7 +425,7 @@ steps:
     outputs:
       - { id: "#peak_call.output_spp_x_cross_corr" }
       - { id: "#peak_call.output_spp_cross_corr_plot" }
-      - { id: "#peak_call.output_peak_file" }
+      - { id: "#peak_call.output_narrowpeak_file" }
       - { id: "#peak_call.output_extended_narrowpeak_file" }
       - { id: "#peak_call.output_peak_xls_file" }
       - { id: "#peak_call.output_filtered_read_count_file" }

--- a/ChIP-seq_pipeline/pipeline-pe-narrow.cwl
+++ b/ChIP-seq_pipeline/pipeline-pe-narrow.cwl
@@ -183,7 +183,7 @@ outputs:
       type: array
       items: File
   - id: "#peak_call_narrowpeak_file"
-    source: "#peak_call.output_peak_file"
+    source: "#peak_call.output_narrowpeak_file"
     description: "Peaks in narrowPeak file format"
     type:
       type: array
@@ -279,7 +279,7 @@ steps:
     outputs:
       - { id: "#peak_call.output_spp_x_cross_corr" }
       - { id: "#peak_call.output_spp_cross_corr_plot" }
-      - { id: "#peak_call.output_peak_file" }
+      - { id: "#peak_call.output_narrowpeak_file" }
       - { id: "#peak_call.output_extended_narrowpeak_file" }
       - { id: "#peak_call.output_peak_xls_file" }
       - { id: "#peak_call.output_filtered_read_count_file" }

--- a/ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
+++ b/ChIP-seq_pipeline/pipeline-se-narrow-with-control.cwl
@@ -205,7 +205,7 @@ outputs:
       type: array
       items: File
   - id: "#peak_call_narrowpeak_file"
-    source: "#peak_call.output_peak_file"
+    source: "#peak_call.output_narrowpeak_file"
     description: "Peaks in narrowPeak file format"
     type:
       type: array
@@ -331,7 +331,7 @@ steps:
     outputs:
       - { id: "#peak_call.output_spp_x_cross_corr" }
       - { id: "#peak_call.output_spp_cross_corr_plot" }
-      - { id: "#peak_call.output_peak_file" }
+      - { id: "#peak_call.output_narrowpeak_file" }
       - { id: "#peak_call.output_extended_narrowpeak_file" }
       - { id: "#peak_call.output_peak_xls_file" }
       - { id: "#peak_call.output_filtered_read_count_file" }

--- a/ChIP-seq_pipeline/pipeline-se-narrow.cwl
+++ b/ChIP-seq_pipeline/pipeline-se-narrow.cwl
@@ -147,7 +147,7 @@ outputs:
       type: array
       items: File
   - id: "#peak_call_narrowpeak_file"
-    source: "#peak_call.output_peak_file"
+    source: "#peak_call.output_narrowpeak_file"
     description: "Peaks in narrowPeak file format"
     type:
       type: array
@@ -232,7 +232,7 @@ steps:
     outputs:
       - { id: "#peak_call.output_spp_x_cross_corr" }
       - { id: "#peak_call.output_spp_cross_corr_plot" }
-      - { id: "#peak_call.output_peak_file" }
+      - { id: "#peak_call.output_narrowpeak_file" }
       - { id: "#peak_call.output_extended_narrowpeak_file" }
       - { id: "#peak_call.output_peak_xls_file" }
       - { id: "#peak_call.output_filtered_read_count_file" }

--- a/DNase-seq_pipeline/02-peakcall.cwl
+++ b/DNase-seq_pipeline/02-peakcall.cwl
@@ -29,7 +29,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_peak_file"
+  - id: "#output_narrowpeak_file"
     source: "#peak-calling-narrow.output_peak_file"
     description: "peakshift/phantomPeak results file"
     type:
@@ -92,10 +92,11 @@ steps:
   - id: "#peak-calling-narrow"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
-      - "#peak-calling-narrow.treatment_sample_file"
+      - "#peak-calling-narrow.treatment"
     inputs:
-      - id: "#peak-calling-narrow.treatment_sample_file"
+      - id: "#peak-calling-narrow.treatment"
         source: "#input_bam_files"
+        valueFrom: $([self])
       - id: "#peak-calling-narrow.extsize"
         valueFrom: $(200)
       - id: "#peak-calling-narrow.nomodel"

--- a/DNase-seq_pipeline/pipeline-se.cwl
+++ b/DNase-seq_pipeline/pipeline-se.cwl
@@ -125,7 +125,7 @@ outputs:
       type: array
       items: File
   - id: "#peak_call_narrowpeak_file"
-    source: "#peak_call.output_peak_file"
+    source: "#peak_call.output_narrowpeak_file"
     description: "Peaks in narrowPeak file format"
     type:
       type: array

--- a/cwl-generator/templates/chipseq-04-peakcall.j2
+++ b/cwl-generator/templates/chipseq-04-peakcall.j2
@@ -44,7 +44,7 @@ outputs:
     type:
       type: array
       items: File
-  - id: "#output_extended_peak_file"
+  - id: "#output_extended_{{ peak_type }}peak_file"
     source: "#peak-calling.output_ext_frag_bdg_file"
     description: "peakshift/phantomPeak extended fragment results file"
     type:
@@ -109,16 +109,18 @@ steps:
   - id: "#peak-calling"
     run: {import: "../peak_calling/macs2-callpeak.cwl"}
     scatter:
+      - "#peak-calling.treatment"
 {% if 'control' in sample_types %}
-      - "#peak-calling.c"
+      - "#peak-calling.control"
 {% endif %}
       - "#peak-calling.extsize"
     scatterMethod: dotproduct
     inputs:
-      - id: "#peak-calling.t"
+      - id: "#peak-calling.treatment"
         source: "#input_bam_files"
+        valueFrom: $([self])
 {% if 'control' in sample_types %}
-      - id: "#peak-calling.c"
+      - id: "#peak-calling.control"
         source: "#input_control_bam_files"
 {% endif %}
 {% if 'broad' == peak_type %}

--- a/peak_calling/macs2-callpeak.cwl
+++ b/peak_calling/macs2-callpeak.cwl
@@ -15,22 +15,22 @@ inputs:
 # ---------------------------------- #
 # ------ Input files arguments ----- #
 # ---------------------------------- #
-  - id: t
+  - id: treatment
     type:
       type: array
       items: File
     description: "Treatment sample file(s). If multiple files are given as -t A B C, then they will all be read and pooled together. IMPORTANT: the first sample will be used as the outputs basename."
     inputBinding:
       position: 2
-      prefix: -t
-  - id: c
+      prefix: --treatment
+  - id: control
     type:
       - 'null'
       - File
     description: 'Control sample file.'
     inputBinding:
       position: 2
-      prefix: -c
+      prefix: --control
   - id: format
     type:
       - 'null'
@@ -344,7 +344,7 @@ outputs:
     type: File
     description: "Peak calling output file in narrowPeak format."
     outputBinding:
-      glob: $(inputs.t[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.*Peak')
+      glob: $(inputs.treatment[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.*Peak')
       outputEval: $(self[0])
   - id: output_ext_frag_bdg_file
     type:
@@ -352,23 +352,23 @@ outputs:
       - File
     description: "Bedgraph with extended fragment pileup."
     outputBinding:
-      glob: $(inputs.t[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
+      glob: $(inputs.treatment[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_treat_pileup.bdg')
   - id: output_peak_xls_file
     type: File
     description: "Peaks information/report file."
     outputBinding:
-      glob: $(inputs.t[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
+      glob: $(inputs.treatment[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_peaks.xls')
   - id: output_peak_summits_file
     type: File
     description: "Peaks summits bedfile."
     outputBinding:
-      glob: $(inputs.t[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
+      glob: $(inputs.treatment[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, '') + '_summits.bed')
 
 baseCommand:
   - macs2
   - callpeak
 
 arguments:
-  - valueFrom: $(inputs.t[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
+  - valueFrom: $(inputs.treatment[0].path.replace(/^.*[\\\/]/, '').replace(/\.[^/.]+$/, ''))
     prefix: "-n"
     position: 1


### PR DESCRIPTION
Mostly cosmetic changes. Noteworthy is the adaptation for creating an array from a source binding a single element. Now macs2-callpeak accepts and array of files instead of a single file, which produces an error between source and sink when parsing the inputs in CWL. The solution is to use valueFrom and a expression which enclose the value of self in an array:
```
id: "#peak-calling.treatment"
source: "#input_bam_files"
valueFrom: $([self])
```