### PR TITLE
Change adapters for UMIs and fix JSON generator

### DIFF
--- a/v1.0/json-generator/consts.py
+++ b/v1.0/json-generator/consts.py
@@ -15,8 +15,11 @@ CPUS = 16
 READ_LENGTH = 50
 
 class ReferenceDataset(object):
-    def __init__(self, genome=GENOME, read_length=READ_LENGTH, with_ercc=False):
-        self.default_adapters = "/data/reddylab/projects/GGR/auxiliary/adapters/default_adapters.fasta"
+    def __init__(self, genome=GENOME, read_length=READ_LENGTH, with_ercc=False, umis=False):
+        if umis:
+            self.default_adapters = "/data/reddylab/Reference_Data/Adapters/trimmomatic_UMI.fa"
+        else:
+            self.default_adapters = "/data/reddylab/Reference_Data/Adapters/default_adapters.fasta"
         self.read_length = read_length
         _genome = genome.lower()
         if _genome == 'hg38' or _genome == 'grch38':

--- a/v1.0/json-generator/run.py
+++ b/v1.0/json-generator/run.py
@@ -319,7 +319,8 @@ class MetadataParserStarrseq(object):
                 for si, s in enumerate(sorted(samples_genomes)):
                     sample, genome = s[0], s[1]
                     ref_dataset = consts.ReferenceDataset(genome,
-                                                          read_length=self.read_length)
+                                                          read_length=self.read_length,
+                                                          umis='umis' in wf_key)
                     self.update_paths(ref_dataset)
 
                     yield self.render_json(wf_conf_dict[wf_key], [sample], data_dir), wf_key, si
@@ -332,7 +333,8 @@ class MetadataParserStarrseq(object):
                         ' per genome or provide a sjdb and specify the --separate-jsons argument' %
                         ', '.join(set(genomes_list)))
                 ref_dataset = consts.ReferenceDataset(genomes_list[0],
-                                                      read_length=self.read_length)
+                                                      read_length=self.read_length,
+                                                      umis='umis' in wf_key)
                 self.update_paths(ref_dataset)
                 yield self.render_json(wf_conf_dict[wf_key], sorted(samples_list), data_dir), wf_key, None
 

--- a/v1.0/json-generator/templates/starr-seq.j2
+++ b/v1.0/json-generator/templates/starr-seq.j2
@@ -27,8 +27,11 @@
     "nthreads_trimm": {{ nthreads }},
     "nthreads_map": {{ nthreads }},
     "nthreads_quant": {{ nthreads }},
+{% if wf_conf['umis'] %}
+    "fgbio_jar_path": "/data/reddylab/software/fgbio/0.8.1/fgbio.jar",
+{% endif %}
     "trimmomatic_jar_path": "/data/reddylab/software/Trimmomatic-0.32/trimmomatic-0.32.jar",
-    "trimmomatic_java_opts": "-Xms{{ (conf_args.mem/2) | round | int }}m -Xmx{{ conf_args.mem }}m"
+    "trimmomatic_java_opts": "-Xms{{ (conf_args.mem/2) | round | int }}m -Xmx{{ conf_args.mem }}m",
     "picard_jar_path": "{{ conf_args.picard_jar }}",
     "picard_java_opts": "-Xms{{ (conf_args.mem/2) | round | int }}m -Xmx{{ conf_args.mem }}m"
 }


### PR DESCRIPTION
The constructs used when including UMIs expand beyond the typical collection Illumina adapters. The new file is a superset of the one used in other pipelines