### PR TITLE
Fix bug in PE ChIP-seq mapping workflow

### DIFF
--- a/v1.0/ChIP-seq_pipeline/03-map-pe.cwl
+++ b/v1.0/ChIP-seq_pipeline/03-map-pe.cwl
@@ -53,13 +53,6 @@ steps:
          valueFrom: ${return true}
      out:
      - basename
-   extract_basename_2:
-     run: ../utils/remove-extension.cwl
-     in:
-       file_path: extract_basename_1/basename
-     scatter: file_path
-     out:
-     - output_path
    bowtie-pe:
      run: ../map/bowtie-pe.cwl
      scatterMethod: dotproduct
@@ -70,7 +63,7 @@ steps:
      in:
        input_fastq_read1_file: input_fastq_read1_files
        input_fastq_read2_file: input_fastq_read2_files
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        v:
          valueFrom: ${return 2}
        X:
@@ -105,7 +98,7 @@ steps:
      - input_file
      - output_filename
      in:
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        input_file: sort_bams/sorted_file
      out:
      - filtered_file
@@ -126,7 +119,7 @@ steps:
      - output_file_basename
      in:
        input_sorted_file: filtered2sorted/sorted_file
-       output_file_basename: extract_basename_2/output_path
+       output_file_basename: extract_basename_1/basename
        pe:
          valueFrom: ${return true}
      out:
@@ -135,7 +128,7 @@ steps:
      in:
        input_bam_files: filtered2sorted/sorted_file
        genome_sizes: genome_sizes_file
-       input_output_filenames: extract_basename_2/output_path
+       input_output_filenames: extract_basename_1/basename
      run: ../map/pcr-bottleneck-coef.cwl
      out:
      - pbc_file
@@ -148,7 +141,7 @@ steps:
      in:
        a: filtered2sorted/sorted_file
        b: ENCODE_blacklist_bedfile
-       output_basename_file: extract_basename_2/output_path
+       output_basename_file: extract_basename_1/basename
        v:
          valueFrom: ${return true}
      out:

--- a/v1.0/ChIP-seq_pipeline/03-map-se.cwl
+++ b/v1.0/ChIP-seq_pipeline/03-map-se.cwl
@@ -50,13 +50,6 @@ steps:
          valueFrom: ${return true}
      out:
      - basename
-   extract_basename_2:
-     run: ../utils/remove-extension.cwl
-     in:
-       file_path: extract_basename_1/basename
-     scatter: file_path
-     out:
-     - output_path
    bowtie-se:
      run: ../map/bowtie-se.cwl
      scatterMethod: dotproduct
@@ -65,7 +58,7 @@ steps:
      - output_filename
      in:
        input_fastq_file: input_fastq_files
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        v:
          valueFrom: ${return 2}
        X:
@@ -100,7 +93,7 @@ steps:
      - input_file
      - output_filename
      in:
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        input_file: sort_bams/sorted_file
      out:
      - filtered_file
@@ -121,14 +114,14 @@ steps:
      - output_file_basename
      in:
        input_sorted_file: filtered2sorted/sorted_file
-       output_file_basename: extract_basename_2/output_path
+       output_file_basename: extract_basename_1/basename
      out:
      - output_file
    execute_pcr_bottleneck_coef:
      in:
        input_bam_files: filtered2sorted/sorted_file
        genome_sizes: genome_sizes_file
-       input_output_filenames: extract_basename_2/output_path
+       input_output_filenames: extract_basename_1/basename
      run: ../map/pcr-bottleneck-coef.cwl
      out:
      - pbc_file
@@ -141,7 +134,7 @@ steps:
      in:
        a: filtered2sorted/sorted_file
        b: ENCODE_blacklist_bedfile
-       output_basename_file: extract_basename_2/output_path
+       output_basename_file: extract_basename_1/basename
        v:
          valueFrom: ${return true}
      out:

--- a/v1.0/cwl-generator/templates/chipseq-03-map.j2
+++ b/v1.0/cwl-generator/templates/chipseq-03-map.j2
@@ -63,13 +63,6 @@ steps:
          valueFrom: ${return true}
      out:
      - basename
-   extract_basename_2:
-     run: ../utils/remove-extension.cwl
-     in:
-       file_path: extract_basename_1/basename
-     scatter: file_path
-     out:
-     - output_path
    bowtie-{{ read_type }}:
      run: ../map/bowtie-{{ read_type }}.cwl
      scatterMethod: dotproduct
@@ -88,7 +81,7 @@ steps:
 {% else %}
        input_fastq_file: input_fastq_files
 {% endif %}
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        v:
          valueFrom: ${return 2}
        X:
@@ -123,7 +116,7 @@ steps:
      - input_file
      - output_filename
      in:
-       output_filename: extract_basename_2/output_path
+       output_filename: extract_basename_1/basename
        input_file: sort_bams/sorted_file
      out:
      - filtered_file
@@ -144,7 +137,7 @@ steps:
      - output_file_basename
      in:
        input_sorted_file: filtered2sorted/sorted_file
-       output_file_basename: extract_basename_2/output_path
+       output_file_basename: extract_basename_1/basename
 {% if read_type == 'pe' %}
        pe:
          valueFrom: ${return true}
@@ -159,7 +152,7 @@ steps:
 {#     scatterMethod: dotproduct#}
 {#     in:#}
 {#       input_sorted_file: filtered2sorted/sorted_file#}
-{#       output_file_basename: extract_basename_2/output_path#}
+{#       output_file_basename: extract_basename_1/basename#}
 {#       s:#}
 {#         valueFrom: ${return 100000}#}
 {#       D:#}
@@ -174,7 +167,7 @@ steps:
      in:
        input_bam_files: filtered2sorted/sorted_file
        genome_sizes: genome_sizes_file
-       input_output_filenames: extract_basename_2/output_path
+       input_output_filenames: extract_basename_1/basename
      run: ../map/pcr-bottleneck-coef.cwl
      out:
      - pbc_file
@@ -188,7 +181,7 @@ steps:
      in:
        a: filtered2sorted/sorted_file
        b: ENCODE_blacklist_bedfile
-       output_basename_file: extract_basename_2/output_path
+       output_basename_file: extract_basename_1/basename
        v:
          valueFrom: ${return true}
      out:


### PR DESCRIPTION
By removing an extra extension the replicate info gets lost and samples of the same condition collide